### PR TITLE
Better error messages when `gh` does not exist

### DIFF
--- a/collect/make_repo/make_repo.sh
+++ b/collect/make_repo/make_repo.sh
@@ -1,12 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
 REPO_TARGET=$1
 
 # Check if the target repository exists
-gh repo view "$REPO_TARGET" > /dev/null 2>&1
-if [ $? -ne 0 ]; then
-    echo "The repository $REPO_TARGET does not exist."
-    exit 1
-fi
+gh repo view "$REPO_TARGET" > /dev/null || exit 1
 
 # Set the organization and repository names
 ORG_NAME="swe-bench"


### PR DESCRIPTION
Also use the more portable `#! /usr/bin/env bash`