### PR TITLE
Use the more portable `.` instead of `source`

### DIFF
--- a/collect/cleanup/remove_envs.py
+++ b/collect/cleanup/remove_envs.py
@@ -69,7 +69,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     # Remove conda environments with a specific prefix
-    conda_source = "source " + os.path.join(args.conda_path, "etc/profile.d/conda.sh")
+    conda_source = ". " + os.path.join(args.conda_path, "etc/profile.d/conda.sh")
     check_env = conda_source + " && " + "conda env list"
     try:
         conda_envs = subprocess.run(check_env.split(" "), check=True, capture_output=True)

--- a/harness/context_manager.py
+++ b/harness/context_manager.py
@@ -281,7 +281,7 @@ class TestbedContextManager:
 
                     # Install dependencies
                     path_to_reqs = get_requirements(setup_ref_instance, self.testbed)
-                    cmd = f"source {path_activate} {env_name} && echo 'activate successful' && pip install -r {path_to_reqs}"
+                    cmd = f". {path_activate} {env_name} && echo 'activate successful' && pip install -r {path_to_reqs}"
                     logger_testbed.info(
                         f"[Testbed] Installing dependencies for {env_name}; Command: {cmd}"
                     )
@@ -326,7 +326,7 @@ class TestbedContextManager:
 
                 # Install additional packages if specified
                 if "pip_packages" in install:
-                    cmd = f"source {path_activate} {env_name} && pip install {install['pip_packages']}"
+                    cmd = f". {path_activate} {env_name} && pip install {install['pip_packages']}"
                     logger_testbed.info(
                         f"[Testbed] Installing pip packages for {env_name}; Command: {cmd}"
                     )
@@ -424,7 +424,7 @@ class TaskEnvContextManager:
             self.log_file = os.path.join(
                 log_dir, f"{instance[KEY_INSTANCE_ID]}.{instance[KEY_MODEL]}.eval.log"
             )
-        self.cmd_activate = f"source {os.path.join(self.conda_path, 'bin', 'activate')} {self.venv} && echo 'activate successful'"
+        self.cmd_activate = f". {os.path.join(self.conda_path, 'bin', 'activate')} {self.venv} && echo 'activate successful'"
         self.timeout = timeout
         self.cwd = os.getcwd()
 

--- a/versioning/get_versions.py
+++ b/versioning/get_versions.py
@@ -140,8 +140,8 @@ def get_versions_from_build(data: Dict):
         data["save_path"],
     )
     # Activate conda environment and set installation command
-    cmd_activate = f"source {os.path.join(path_conda, 'bin/activate')}"
-    cmd_source = f"source {os.path.join(path_conda, 'etc/profile.d/conda.sh')}"
+    cmd_activate = f". {os.path.join(path_conda, 'bin/activate')}"
+    cmd_source = f". {os.path.join(path_conda, 'etc/profile.d/conda.sh')}"
     cmd_install = INSTALL_CMD[data_tasks[0]["repo"]]
 
     # Change directory to repo testbed


### PR DESCRIPTION
This avoids errors such as `/bin/sh: 1: source: not found` when `/bin/sh` is, e.g., dash.

```
$ python harness/run_evaluation.py     --predictions_path example-predictions.json  --swe_bench_tasks example.json     --log_dir example-log/     --testbed example-testbed/
Error: Command 'source /home/jgross/Documents/GitHub/SWE-bench/example-testbed/fakemodel/sqlfluff__sqlfluff/1.4/tmpdx4urtao/miniconda3/bin/activate sqlfluff__sqlfluff__1.4 && echo 'activate successful' && pip install -r /home/jgross/Documents/GitHub/SWE-bench/example-testbed/fakemodel/sqlfluff__sqlfluff/1.4/tmpfnim3stm/requirements.txt' returned non-zero exit status 127.
Error stdout:
Error stderr: /bin/sh: 1: source: not found

Error traceback: Traceback (most recent call last):
  File "/home/jgross/Documents/GitHub/SWE-bench/harness/context_manager.py", line 50, in __call__
    output = subprocess.run(cmd, **combined_args)
  File "/home/jgross/.local64/mambaforge/envs/swe-bench/lib/python3.9/subprocess.py", line 528, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command 'source /home/jgross/Documents/GitHub/SWE-bench/example-testbed/fakemodel/sqlfluff__sqlfluff/1.4/tmpdx4urtao/miniconda3/bin/activate sqlfluff__sqlfluff__1.4 && echo 'activate successful' && pip install -r /home/jgross/Documents/GitHub/SWE-bench/example-testbed/fakemodel/sqlfluff__sqlfluff/1.4/tmpfnim3stm/requirements.txt' returned non-zero exit status 127.

Traceback (most recent call last):
  File "/home/jgross/Documents/GitHub/SWE-bench/harness/run_evaluation.py", line 186, in <module>
    main(**vars(args))
  File "/home/jgross/Documents/GitHub/SWE-bench/harness/run_evaluation.py", line 162, in main
    eval_engine(args)
  File "/home/jgross/Documents/GitHub/SWE-bench/harness/engine_evaluation.py", line 164, in main
    setup_testbed(data_groups[0])
  File "/home/jgross/Documents/GitHub/SWE-bench/harness/engine_validation.py", line 89, in setup_testbed
    with TestbedContextManager(
  File "/home/jgross/Documents/GitHub/SWE-bench/harness/context_manager.py", line 288, in __enter__
    self.exec(cmd, shell=True)
  File "/home/jgross/Documents/GitHub/SWE-bench/harness/context_manager.py", line 58, in __call__
    raise e
  File "/home/jgross/Documents/GitHub/SWE-bench/harness/context_manager.py", line 50, in __call__
    output = subprocess.run(cmd, **combined_args)
  File "/home/jgross/.local64/mambaforge/envs/swe-bench/lib/python3.9/subprocess.py", line 528, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command 'source /home/jgross/Documents/GitHub/SWE-bench/example-testbed/fakemodel/sqlfluff__sqlfluff/1.4/tmpdx4urtao/miniconda3/bin/activate sqlfluff__sqlfluff__1.4 && echo 'activate successful' && pip install -r /home/jgross/Documents/GitHub/SWE-bench/example-testbed/fakemodel/sqlfluff__sqlfluff/1.4/tmpfnim3stm/requirements.txt' returned non-zero exit status 127.
```