### PR TITLE
fix(get_conda_env_names): handle lines with only path in `conda env l…

### DIFF
--- a/harness/utils.py
+++ b/harness/utils.py
@@ -47,9 +47,12 @@ def get_conda_env_names(conda_source: str, env: dict = None) -> List:
             continue
         if line.strip() == "":
             continue
-        if " " in line:
-            env_name = line.split(" ")[0]
-            env_names.append(env_name)
+        parts = line.split()
+        if len(parts) == 2:
+            env_name = parts[0]
+        elif len(parts) == 1:
+            env_name = parts[0].split('/')[-1]
+        env_names.append(env_name)
     return env_names
 
 


### PR DESCRIPTION
…ist` output

This commit enhanced parsing of `conda env list` output in script.

This update improves the script's ability to parse the output of `conda env list`. The previous version of the script only handled lines that contained both an environment name and a path. However, in some cases, the `conda env list` output includes lines with only a path and no environment name.

For example, the output can be,
```bash
# conda environments:
#
base                     /home/pai
                         /home/taow/.conda/envs/psf__requests__2.10
                         /home/taow/anaconda3/envs/astropy__astropy__1.3
                         /home/taow/anaconda3/envs/astropy__astropy__3.0
                         /home/taow/anaconda3/envs/astropy__astropy__3.1
```


Modifications:
- Added logic to handle lines with only a single path. In such cases, the environment name is inferred from the last part of the path.

