### PR TITLE
Make scripts executable and add `description` field to `ArgumentParser`

### DIFF
--- a/collect/build_dataset.py
+++ b/collect/build_dataset.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import argparse
 import json
 import logging

--- a/collect/build_dataset_ft.py
+++ b/collect/build_dataset_ft.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import argparse
 import glob
 import json

--- a/collect/cleanup/delete_gh_workflows.py
+++ b/collect/cleanup/delete_gh_workflows.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import argparse
 import os
 import subprocess

--- a/collect/cleanup/remove_envs.py
+++ b/collect/cleanup/remove_envs.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import argparse
 import os
 import subprocess

--- a/collect/get_top_pypi.py
+++ b/collect/get_top_pypi.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import os, json
 
 from bs4 import BeautifulSoup

--- a/collect/make_repo/call_make_repo.py
+++ b/collect/make_repo/call_make_repo.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import subprocess
 
 repos = ["Repos here"]

--- a/collect/print_pulls.py
+++ b/collect/print_pulls.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import argparse
 import json
 import logging

--- a/collect/print_pulls.py
+++ b/collect/print_pulls.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+"""Given the `<owner/name>` of a GitHub repo, this script writes the raw information for all the repo's PRs to a single `.jsonl` file."""
+
 import argparse
 import json
 import logging
@@ -46,7 +48,7 @@ def main(repo_name: str, output: str, token: Optional[str] = None):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("repo_name", type=str, help="Name of the repository")
     parser.add_argument("output", type=str, help="Output file name")
     parser.add_argument("--token", type=str, help="GitHub token")

--- a/harness/run_evaluation.py
+++ b/harness/run_evaluation.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python3
+
+"""Run evaluation"""
 import argparse
 import datasets
 import hashlib

--- a/harness/run_evaluation.py
+++ b/harness/run_evaluation.py
@@ -225,7 +225,7 @@ def main(
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--predictions_path", type=str, help="Path to predictions file (must be .json)", required=True)
     parser.add_argument("--log_dir", type=str, help="Path to log directory", required=True)
     parser.add_argument("--swe_bench_tasks", type=str, help="Path to SWE-bench task instances file", required=True)

--- a/inference/make_datasets/create_text_dataset.py
+++ b/inference/make_datasets/create_text_dataset.py
@@ -179,7 +179,7 @@ def main(
 
 
 if __name__ == "__main__":
-    parser = ArgumentParser()
+    parser = ArgumentParser(description=__doc__)
     parser.add_argument(
         "--dataset_name_or_path",
         type=str,

--- a/inference/make_datasets/create_text_dataset.py
+++ b/inference/make_datasets/create_text_dataset.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 """
 Create a dataset for text-to-text training from the raw task instance outputs.
 """

--- a/inference/make_datasets/eval_retrieval.py
+++ b/inference/make_datasets/eval_retrieval.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import re
 import numpy as np
 from datasets import load_dataset, disable_caching, load_from_disk

--- a/inference/make_datasets/eval_retrieval.py
+++ b/inference/make_datasets/eval_retrieval.py
@@ -1,4 +1,7 @@
+
 #!/usr/bin/env python
+
+"""This script can be used to evaluate the BM25 retrieval results for a dataset created with create_text_dataset.py with the --retrieval_file option and --file_source bm25."""
 
 import re
 import numpy as np
@@ -49,7 +52,7 @@ def main(dataset_name_or_path, split):
     
 
 if __name__ == "__main__":
-    parser = ArgumentParser()
+    parser = ArgumentParser(description=__doc__)
     parser.add_argument('--dataset_name_or_path', type=str, default='princeton-nlp/SWE-bench_bm25_13K')
     parser.add_argument('--split', type=str, default='test')
     args = parser.parse_args()

--- a/inference/make_datasets/tokenize_dataset.py
+++ b/inference/make_datasets/tokenize_dataset.py
@@ -193,7 +193,7 @@ def main(
 
 
 if __name__ == "__main__":
-    parser = ArgumentParser()
+    parser = ArgumentParser(description=__doc__)
     parser.add_argument("--dataset_name_or_path", type=str, required=True)
     parser.add_argument("--output_dir", type=str, required=True)
     parser.add_argument(

--- a/inference/make_datasets/tokenize_dataset.py
+++ b/inference/make_datasets/tokenize_dataset.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 """Provided a source (raw) directory and the final (eval) directory, create a training split by removing all instances that are in the final directory from the source directory.
 """
 

--- a/inference/run_api.py
+++ b/inference/run_api.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import json
 import os
 import time

--- a/inference/run_api.py
+++ b/inference/run_api.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 
+"""This python script is designed to run inference on a dataset using either the OpenAI or Anthropic API, depending on the model specified. 
+It sorts instances by length and continually writes the outputs to a specified file, so that the script can be stopped and restarted without losing progress.
+"""
+
 import json
 import os
 import time
@@ -436,7 +440,7 @@ def main(
 
 
 if __name__ == "__main__":
-    parser = ArgumentParser()
+    parser = ArgumentParser(description=__doc__)
     parser.add_argument(
         "--dataset_name_or_path",
         type=str,

--- a/inference/run_live.py
+++ b/inference/run_live.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 """
 This module contains functions for running a live inference session on a GitHub issue.
 It clones the repository associated with the issue, builds a BM25 retrieval index, and

--- a/inference/run_live.py
+++ b/inference/run_live.py
@@ -255,7 +255,7 @@ def main(
 
 
 if __name__ == "__main__":
-    parser = ArgumentParser()
+    parser = ArgumentParser(description=__doc__)
     parser.add_argument("--model_name", type=str)
     parser.add_argument(
         "--prompt_style", type=str, choices=PROMPT_FUNCTIONS.keys(), default="style-3"


### PR DESCRIPTION
1. Mark scripts as executable/add shebang 
2. Add the docstring (`__doc__`) also as `description` for `ArgumentParser`. This way, it will show up in the first line if users do `./script --help`.