### PR TITLE
Handle the case when a conda environment is selected

### DIFF
--- a/harness/utils.py
+++ b/harness/utils.py
@@ -47,6 +47,8 @@ def get_conda_env_names(conda_source: str, env: dict = None) -> list:
         if line.strip() == "":
             continue
         parts = line.split()
+        if len(parts) == 3:
+            env_name = parts[0]
         if len(parts) == 2:
             env_name = parts[0]
         elif len(parts) == 1:


### PR DESCRIPTION
This PR fixes issue #66

By my understanding, this issue occurs because, when a Conda environment is activated, it is marked with a star `*` in the same line. This makes `parts` have three elements when we parse the output of `conda env list`, and this case is not handled, therefore `env_name` is not assigned. See below.

```bash
$ conda env list
# conda environments:
#
                      ⬇️ Troublesome!
base                  *  /work/miniconda3
codenet                  /work/miniconda3/envs/codenet
mnist                    /work/miniconda3/envs/mnist
```

I fixed the issue by handling this case explicitly.