### PR TITLE
Share conda environment across evals

### DIFF
--- a/swebench/harness/context_manager.py
+++ b/swebench/harness/context_manager.py
@@ -229,16 +229,25 @@ class TestbedContextManager:
         """
         Set up testbed (conda environments, git repositories)
         """
-        # If path_conda not provided, create temporary miniconda3 installation
+        # If path_conda not provided or does not exist, create a miniconda3 installation
         is_osx_64 = False
         if platform.system() == "Darwin" and platform.machine() == "arm64":
             is_osx_64 = True
+
+        install_conda = False
         if self.temp_dir_conda is not None:
-            # Set up the paths for Miniconda
             self.path_conda = os.path.join(self.path_conda, "miniconda3")
-            os.mkdir(self.path_conda)
-            miniconda_sh = os.path.join(self.path_conda, "miniconda.sh")
             self.log.write(f"No conda path provided, creating temporary install in {self.path_conda}...")
+            os.mkdir(self.path_conda)
+            install_conda = True
+        elif not os.path.exists(self.path_conda):
+            self.log.write(f"Conda path does not exist, creating install in {self.path_conda}...")
+            os.makedirs(self.path_conda)
+            install_conda = True
+
+        if install_conda:
+            # Set up the paths for Miniconda
+            miniconda_sh = os.path.join(self.path_conda, "miniconda.sh")
 
             # Download Miniconda installer
             if self.conda_link is not None:

--- a/swebench/harness/run_evaluation.py
+++ b/swebench/harness/run_evaluation.py
@@ -89,7 +89,7 @@ def main(
         raise ValueError("--log_dir must exist and point at a directory")
     if not os.path.exists(testbed) or not os.path.isdir(testbed):
         raise ValueError("--testbed must exist and point at a directory")
-    
+
     tasks = list(get_eval_refs(swe_bench_tasks).values())
 
     # Verify arguments are formatted correctly
@@ -153,6 +153,7 @@ def main(
                 args.predictions_path = file_path
                 args.skip_existing = skip_existing
                 args.temp_dir = testbed_model_repo_version_dir
+                args.path_conda = os.path.join(testbed, "conda", repo.rsplit('__', 1)[-1], version)
                 args.timeout = timeout
                 args.verbose = verbose
                 args.conda_link = conda_link

--- a/swebench/harness/run_evaluation.py
+++ b/swebench/harness/run_evaluation.py
@@ -153,7 +153,7 @@ def main(
                 args.predictions_path = file_path
                 args.skip_existing = skip_existing
                 args.temp_dir = testbed_model_repo_version_dir
-                args.path_conda = os.path.join(testbed, "conda", repo.rsplit('__', 1)[-1], version)
+                args.path_conda = os.path.join(testbed, "conda", repo.rsplit('__', 1)[-1], version, "envs", f"{repo}__{version}")
                 args.timeout = timeout
                 args.verbose = verbose
                 args.conda_link = conda_link
@@ -181,7 +181,7 @@ def main(
                         repo_version_predictions = predictions_filtered
                 else:
                     logger.info(f"[{model}/{repo}/{version}] # of predictions to evaluate: {len(repo_version_predictions)}")
-                
+
                 # Save predictions to file
                 with open(file_path, "w") as f:
                     json.dump(repo_version_predictions, f, indent=4)

--- a/swebench/harness/utils.py
+++ b/swebench/harness/utils.py
@@ -30,7 +30,7 @@ def get_conda_env_names(conda_source: str, env: dict = None) -> list:
     # Get list of conda environments
     try:
         conda_envs = subprocess.run(
-            f"{conda_source} env list".split(" "), check=True, capture_output=True, text=True, env=env,
+            f"{conda_source} env list --json".split(" "), check=True, capture_output=True, text=True, env=env,
         )
     except subprocess.CalledProcessError as e:
         print(f"Error: {e}")
@@ -38,20 +38,8 @@ def get_conda_env_names(conda_source: str, env: dict = None) -> list:
         print(f"Error stderr: {e.stderr}")
         raise e
     output = conda_envs.stdout
-    lines = output.split("\n")
-    # Store environment names to list
-    env_names = []
-    for line in lines:
-        if line.startswith("#"):
-            continue
-        if line.strip() == "":
-            continue
-        parts = line.split()
-        if len(parts) <= 1:
-            continue
-        env_name = parts[1]
-        env_names.append(env_name)
-    return env_names
+    envs = json.loads(output)
+    return [e.split("/")[-1] for e in envs["envs"]]
 
 
 def get_environment_yml(
@@ -439,7 +427,7 @@ def has_attribute_or_import_error(log_before):
                 if target_word in line:
                     hits.append(line)
             return hits
-        
+
         # Get line with Attribute/Import error
         lines_1 = get_lines_with_word(log_before, 'attribute')
         lines_2 = get_lines_with_word(log_before, 'import')


### PR DESCRIPTION
This change provides a `path_conda` to use for the eval in the testbed directory that will be reused across evaluations, and modifies the context manager's behavior so that a non-existent `path_conda` will be initialized and populated in the same way that a temporary context would be.

I realize that it might make some sense to have a bit of discussion about optionalizing this behavior, but I wanted to just get something out there to talk about. :)

Fixes #104.
