### PR TITLE
Do not attempt to mutate dataset object

### DIFF
--- a/swebench/metrics/getters.py
+++ b/swebench/metrics/getters.py
@@ -142,9 +142,11 @@ def get_eval_refs(data_path_or_name):
         for split in data.keys():
             all_data.extend(data[split])
         data = all_data
-    if decode_keys:
-        for datum in data:
-            for key in ["PASS_TO_PASS", "FAIL_TO_PASS"]:
-                datum[key] = json.loads(datum[key])
-    return {d[KEY_INSTANCE_ID]: d for d in data}
 
+    def _maybe_decode_keys(d):
+        if decode_keys:
+            for key in ["PASS_TO_PASS", "FAIL_TO_PASS"]:
+                d[key] = json.loads(d[key])
+        return d
+
+    return {d[KEY_INSTANCE_ID]: _maybe_decode_keys(d) for d in data}


### PR DESCRIPTION
It turns out that `load_from_disk` returns a `Dataset` object that _looks_ like a list but isn't. So trying to mutate the dicts in place silently fails to do anything at all.

Instead of trying to mutate the dataset in-place (which we'll copy into a list anyway), just call a helper function that will deal with mangling the dict as necessary while we enumerate dataset.

Fixes #107.

