### PR TITLE
Add error handling for repo cloning

### DIFF
--- a/swebench/harness/context_manager.py
+++ b/swebench/harness/context_manager.py
@@ -321,8 +321,10 @@ class TestbedContextManager:
                 # Clone github per repo/version
                 repo_path = os.path.join(self.testbed, env_name)
                 if not os.path.exists(repo_path):
-                    clone_repo(repo, repo_path)
-                    self.log.write(f"Cloned {repo} to {repo_path}")
+                    if clone_repo(repo, repo_path):
+                        self.log.write(f"Cloned {repo} to {repo_path}")
+                    else:
+                        raise Exception(f"Failed to clone {repo} to {repo_path}")
                 else:
                     self.log.write(f"Repo for {repo_prefix} version {version} exists: {repo_path}; skipping")
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!
-->

#### Reference Issues/PRs
<!--
Example: "Fixes #1234", "See also #3456"
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Explain your changes.
<!--
Please include a brief explanation of how your solution
fixes the tagged issue(s), along with what files / entities have
been modified for this fix.
-->
This PR modifies the `clone_repo` function call in `context_manager.py` to handle failures more gracefully. The original implementation could lead to confusing `FileNotFoundError` messages. The new implementation checks if the `clone_repo` function succeeds and raises an explicit exception if it fails, providing a clearer error message.

Original implementation output:
```
Cmd('git') failed due to: exit code(128)
  cmdline: git clone -v -- https://*****@*****hub.com/swe-bench/django__django.git /Users/joezhu/dev/SWE-agent/evaluation/testbed/54f1acd8dd/django/3.1/tmppag9rw_s/django__django__3.1
  stderr: 'Cloning into '/Users/joezhu/dev/SWE-agent/evaluation/testbed/54f1acd8dd/django/3.1/tmppag9rw_s/django__django__3.1'...
POST git-upload-pack (175 bytes)
POST git-upload-pack (gzip 20567 to 10338 bytes)
error: 6737 bytes of body are still expected
fetch-pack: unexpected disconnect while reading sideband packet
fatal: early EOF
fatal: fetch-pack: invalid index-pack output
'
2024-05-20 00:31:05,969 - testbed - INFO - Cloned django/django to /Users/joezhu/dev/SWE-agent/evaluation/testbed/54f1acd8dd/django/3.1/tmppag9rw_s/django__django__3.1
2024-05-20 00:31:05,969 - testbed - INFO - Creating environment django__django__3.1
2024-05-20 00:31:42,454 - testbed - INFO - Installing dependencies for django__django__3.1; Command: . /Users/joezhu/dev/SWE-agent/evaluation/testbed/54f1acd8dd/django/3.1/tmpbd9g2x0y/miniconda3/bin/activate django__django__3.1 && echo 'activate successful' && pip install -r /Users/joezhu/dev/SWE-agent/evaluation/testbed/54f1acd8dd/django/3.1/tmppag9rw_s/requirements.txt
/Users/joezhu/dev/SWE-agent/evaluation/testbed/54f1acd8dd/django/3.1/tmppag9rw_s/django__django__3.1: 1 instances
❌ Evaluation failed: [Errno 2] No such file or directory: 
'/Users/joezhu/dev/SWE-agent/evaluation/testbed/54f1acd8dd/django/3.1/tmppag9rw_s/django__django__3.1'
Traceback (most recent call last):
  File "/Users/joezhu/dev/SWE-agent/evaluation/evaluation.py", line 58, in main
    run_evaluation(
  File "/Users/joezhu/dev/SWE-agent/venv/lib/python3.10/site-packages/swebench/harness/run_evaluation.py", line 200, in main
    eval_engine(args)
  File "/Users/joezhu/dev/SWE-agent/venv/lib/python3.10/site-packages/swebench/harness/engine_evaluation.py", line 172, in main
    setup_testbed(data_groups[0])
  File "/Users/joezhu/dev/SWE-agent/venv/lib/python3.10/site-packages/swebench/harness/engine_validation.py", line 108, in 
setup_testbed
    data_dict.func(distributed_task_list[0])
  File "/Users/joezhu/dev/SWE-agent/venv/lib/python3.10/site-packages/swebench/harness/engine_evaluation.py", line 95, in 
evaluate_predictions
    with TaskEnvContextManager(
  File "/Users/joezhu/dev/SWE-agent/venv/lib/python3.10/site-packages/swebench/harness/context_manager.py", line 538, in __enter__
    os.chdir(self.testbed)
FileNotFoundError: [Errno 2] No such file or directory: 
'/Users/joezhu/dev/SWE-agent/evaluation/testbed/54f1acd8dd/django/3.1/tmppag9rw_s/django__django__3.1'
```
#### Other comments