### PR TITLE
Fix astropy installation after setuptools updated to 70.0.0

### DIFF
--- a/swebench/harness/constants.py
+++ b/swebench/harness/constants.py
@@ -372,6 +372,7 @@ MAP_VERSION_TO_INSTALL_ASTROPY = {
             "pytest-mock==3.11.1", "pytest-openfiles==0.5.0", "pytest-remotedata==0.4.0", "pytest-xdist==3.3.1",
             "pytest==7.4.0", "PyYAML==6.0.1", "setuptools==68.0.0", "sortedcontainers==2.4.0", "tomli==2.0.1",
         ],
+        "pre_install": ['sed -i \'s/requires = \\["setuptools",/requires = \\["setuptools==68.0.0",/\' pyproject.toml'],
     }
     for k in
         ["0.1", "0.2", "0.3", "0.4", "1.1", "1.2", "1.3", "3.0", "3.1", "3.2"] + \


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!
-->

#### Reference Issues/PRs
<!--
Example: "Fixes #1234", "See also #3456"
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #127

#### What does this implement/fix? Explain your changes.
<!--
Please include a brief explanation of how your solution
fixes the tagged issue(s), along with what files / entities have
been modified for this fix.
-->
This adds a pre_install step to astropy/astropy instances to fix the pyproject.toml requirement for setuptools to version 68.0.0. After the update of setuptools to [70.0.0](https://pypi.org/project/setuptools/70.0.0/), the build breaks.
This should fix recent astropy/astropy installation problems. Looking into other issues for Django, etc..

#### Any other comments?

🧡 Thanks for contributing!
