### PR TITLE
Add pytest to pydicom requirements

### DIFF
--- a/swebench/harness/constants.py
+++ b/swebench/harness/constants.py
@@ -513,7 +513,7 @@ MAP_VERSION_TO_INSTALL_PYDICOM = {
     k: {
         "python": "3.6",
         "install": "pip install -e .",
-        "packages": "numpy"
+        "packages": "numpy pytest"
     }
     for k in ['1.2', '1.3', '1.4', '2.0', '2.1', '2.2', '2.3']
 }


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
Currently instances from swebench with repo="pydicom/pydicom" do not work due to the absence of pytest. I added pytest to `packages`.