### PR TITLE
Fix evaluation hanging issue and improve patch apply

### DIFF
--- a/swebench/harness/run_evaluation.py
+++ b/swebench/harness/run_evaluation.py
@@ -188,11 +188,15 @@ def run_instance(
             f.write(json.dumps(report, indent=4))
         return instance_id, report
     except EvaluationError as e:
-        error_msg = f"EvaluationError {instance_id}: {e}\n{traceback.format_exc()}"
+        error_msg = (f"EvaluationError {instance_id}: {e}\n"
+                     f"{traceback.format_exc()}\n"
+                     f"Check ({logger.log_path}) for more information.")
         logger.info(error_msg)
         print(error_msg)
     except Exception as e:
-        error_msg = f"Error in evaluating model for {instance_id}: {e}\n{traceback.format_exc()}"
+        error_msg = (f"Error in evaluating model for {instance_id}: {e}\n"
+                     f"{traceback.format_exc()}\n"
+                     f"Check ({logger.log_path}) for more information.")
         logger.info(error_msg)
         print(error_msg)
     finally:

--- a/swebench/harness/run_evaluation.py
+++ b/swebench/harness/run_evaluation.py
@@ -190,13 +190,13 @@ def run_instance(
     except EvaluationError as e:
         error_msg = (f"EvaluationError {instance_id}: {e}\n"
                      f"{traceback.format_exc()}\n"
-                     f"Check ({logger.log_path}) for more information.")
+                     f"Check ({logger.log_file}) for more information.")
         logger.info(error_msg)
         print(error_msg)
     except Exception as e:
         error_msg = (f"Error in evaluating model for {instance_id}: {e}\n"
                      f"{traceback.format_exc()}\n"
-                     f"Check ({logger.log_path}) for more information.")
+                     f"Check ({logger.log_file}) for more information.")
         logger.info(error_msg)
         print(error_msg)
     finally:

--- a/swebench/harness/run_evaluation.py
+++ b/swebench/harness/run_evaluation.py
@@ -188,11 +188,13 @@ def run_instance(
             f.write(json.dumps(report, indent=4))
         return instance_id, report
     except EvaluationError as e:
-        print(f"EvaluationError {instance_id}: {e}")
-        print(traceback.format_exc())
+        error_msg = f"EvaluationError {instance_id}: {e}\n{traceback.format_exc()}"
+        logger.info(error_msg)
+        print(error_msg)
     except Exception as e:
-        print(f"Error in evaluating model for {instance_id}: {e}")
-        print(traceback.format_exc())
+        error_msg = f"Error in evaluating model for {instance_id}: {e}\n{traceback.format_exc()}"
+        logger.info(error_msg)
+        print(error_msg)
     finally:
         # Remove instance container + image, close logger
         cleanup_container(client, container, logger)

--- a/swebench/harness/run_evaluation.py
+++ b/swebench/harness/run_evaluation.py
@@ -119,12 +119,23 @@ def run_instance(
             user="root",
         )
         if val.exit_code != 0:
-            logger.info(f"{APPLY_PATCH_FAIL}:\n{val.output.decode('utf-8')}")
-            raise EvaluationError(
-                instance_id,
-                f"{APPLY_PATCH_FAIL}:\n{val.output.decode('utf-8')}",
-                logger,
+            logger.info(f"Failed to apply patch to container, trying again...")
+            
+            # try "patch --batch --fuzz=5 -p1 -i {patch_path}" to try again
+            val = container.exec_run(
+                "patch --batch --fuzz=5 -p1 -i /tmp/patch.diff",
+                workdir="/testbed",
+                user="root",
             )
+            if val.exit_code != 0:
+                logger.info(f"{APPLY_PATCH_FAIL}:\n{val.output.decode('utf-8')}")
+                raise EvaluationError(
+                    instance_id,
+                    f"{APPLY_PATCH_FAIL}:\n{val.output.decode('utf-8')}",
+                    logger,
+                )
+            else:
+                logger.info(f"{APPLY_PATCH_PASS}:\n{val.output.decode('utf-8')}")
         else:
             logger.info(f"{APPLY_PATCH_PASS}:\n{val.output.decode('utf-8')}")
 

--- a/swebench/harness/run_evaluation.py
+++ b/swebench/harness/run_evaluation.py
@@ -177,18 +177,17 @@ def run_instance(
             f.write(json.dumps(report, indent=4))
         return instance_id, report
     except EvaluationError as e:
-        raise EvaluationError(instance_id, str(e), logger) from e
+        print(f"EvaluationError {instance_id}: {e}")
+        print(traceback.format_exc())
     except Exception as e:
-        logger.error(f"Error in evaluating model for {instance_id}: {e}")
-        logger.info(traceback.format_exc())
-        raise EvaluationError(instance_id, str(e), logger) from e
+        print(f"Error in evaluating model for {instance_id}: {e}")
+        print(traceback.format_exc())
     finally:
         # Remove instance container + image, close logger
         cleanup_container(client, container, logger)
         if rm_image:
             remove_image(client, test_spec.instance_image_key, logger)
         close_logger(logger)
-
 
 def run_instances(
         predictions: dict,
@@ -254,9 +253,6 @@ def run_instances(
                 try:
                     # Update progress bar, check if instance ran successfully
                     future.result()
-                except EvaluationError as e:
-                    print(f"EvaluationError {e.instance_id}: {e}")
-                    continue
                 except Exception as e:
                     traceback.print_exc()
                     continue


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!
-->

Thanks for the new containerized version of SWE-Bench! Looks really exciting and promising!

#### Reference Issues/PRs
<!--
Example: "Fixes #1234", "See also #3456"
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Maybe fix https://github.com/princeton-nlp/SWE-bench/issues/158, https://github.com/princeton-nlp/SWE-bench/issues/157.


#### What does this implement/fix? Explain your changes.
<!--
Please include a brief explanation of how your solution
fixes the tagged issue(s), along with what files / entities have
been modified for this fix.
-->

1.  I found that when calling `future.result()`, the SWE-Bench evaluation can hang for a long time (as described in https://github.com/princeton-nlp/SWE-bench/issues/158). But if you add a `return` statement after [this line](https://github.com/princeton-nlp/SWE-bench/blob/68d80593ec19c55ff2f9dcd8e72632dcd8b2cc5e/swebench/harness/run_evaluation.py#L190-L191), the hanging will be fixed, but a lot of evaluation instances will run into "errors" because report file will not be written. I track the issue down to the [exception thrown inside `run_instance` function](https://github.com/princeton-nlp/SWE-bench/blob/68d80593ec19c55ff2f9dcd8e72632dcd8b2cc5e/swebench/harness/run_evaluation.py#L179-L184): when evaluation is thrown (e.g., error produced), it seems to break the `future.results()` and cause it to hang indefinitely. Since the reason why we want to throw that error is to print the error to stdout, i modify the code to directly print the error messages inside `run_instance` and get rid of the exception throwing, which hopefully would resolve the error directly.

2. I added an alternative fuzzy patch apply mechanism (when the simple `git apply` failed) from OpenDevin's current evaluation implementation (https://github.com/OpenDevin/SWE-bench-docker/pull/1) so that more potential patches (e.g., failed due to simple format issues) can be applied.
