### PR TITLE
Fix so it doesn't crash when no env imgs to build

### DIFF
--- a/swebench/harness/docker_build.py
+++ b/swebench/harness/docker_build.py
@@ -281,7 +281,7 @@ def build_env_images(
     configs_to_build = get_env_configs_to_build(client, dataset)
     if len(configs_to_build) == 0:
         print("No environment images need to be built.")
-        return
+        return [], []
     print(f"Total environment images to build: {len(configs_to_build)}")
 
     # Build the environment images


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!
-->

#### Reference Issues/PRs
<!--
Example: "Fixes #1234", "See also #3456"
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Explain your changes.
If you run `python -m swebench.harness.prepare_images` with all env images already built, `build_env_images` exits early and returns None. This causes the program to crash [here](https://github.com/princeton-nlp/SWE-bench/blob/main/swebench/harness/docker_build.py#L355) because it expects a `Tuple[list, list]`. Easy fix just returns two empty lists when we exit early.

#### Any other comments?

🧡 Thanks for contributing!
