### PR TITLE
Don't let tox install a virtualenv during evaluation

### DIFF
--- a/swebench/harness/constants.py
+++ b/swebench/harness/constants.py
@@ -444,7 +444,7 @@ MAP_VERSION_TO_INSTALL_MATPLOTLIB.update(
 MAP_VERSION_TO_INSTALL_SPHINX = {
     k: {
         "python": "3.9",
-        "pip_packages": ["tox"],
+        "pip_packages": ["tox", "tox-current-env"],
         "install": "python -m pip install -e .[test]",
         "pre_install": ["sed -i 's/pytest/pytest -rA/' tox.ini"],
     }
@@ -842,7 +842,7 @@ MAP_REPO_TO_TEST_FRAMEWORK = {
         k: TEST_PYTEST for k in MAP_VERSION_TO_INSTALL_SKLEARN.keys()
     },
     "sphinx-doc/sphinx": {
-        k: "tox -epy39 -v --" for k in MAP_VERSION_TO_INSTALL_SPHINX.keys()
+        k: "tox --current-env -epy39 -v --" for k in MAP_VERSION_TO_INSTALL_SPHINX.keys()
     },
     "sqlfluff/sqlfluff": {
         k: TEST_PYTEST for k in MAP_VERSION_TO_INSTALL_SQLFLUFF.keys()
@@ -906,7 +906,7 @@ MAP_REPO_TO_TEST_FRAMEWORK_VERBOSE = {
         k: TEST_PYTEST_VERBOSE for k in MAP_VERSION_TO_INSTALL_SKLEARN.keys()
     },
     "sphinx-doc/sphinx": {
-        k: "tox -epy39 -v --" for k in MAP_VERSION_TO_INSTALL_SPHINX.keys()
+        k: "tox --current-env -epy39 -v --" for k in MAP_VERSION_TO_INSTALL_SPHINX.keys()
     },
     "sqlfluff/sqlfluff": {
         k: TEST_PYTEST_VERBOSE for k in MAP_VERSION_TO_INSTALL_SQLFLUFF.keys()


### PR DESCRIPTION
By default, `tox` will try to create a virtualenv in which to reinstall all of the dependencies. We don't need this level of isolation for SWE-bench, so use the `tox-current-env` plugin to elide that.

#### Reference Issues/PRs

Fixes #170.

#### What does this implement/fix? Explain your changes.

Use the `tox-current-env` plugin to tell `tox` not to try to install its own venv.

#### Any other comments?

🧡 Thanks for contributing!
