### PR TITLE
Fix timeout

### DIFF
--- a/swebench/harness/docker_build.py
+++ b/swebench/harness/docker_build.py
@@ -29,13 +29,14 @@ ansi_escape = re.compile(r"\x1B\[[0-?]*[ -/]*[@-~]")
 class BuildImageError(Exception):
     def __init__(self, image_name, message, logger):
         super().__init__(message)
+        self.super_str = super().__str__()
         self.image_name = image_name
         self.log_path = logger.log_file
         self.logger = logger
 
     def __str__(self):
         return (
-            f"{self.image_name}: {super().__str__()}\n"
+            f"Error building image {self.image_name}: {self.super_str}\n"
             f"Check ({self.log_path}) for more information."
         )
 

--- a/swebench/harness/docker_build.py
+++ b/swebench/harness/docker_build.py
@@ -34,8 +34,6 @@ class BuildImageError(Exception):
         self.logger = logger
 
     def __str__(self):
-        log_msg = traceback.format_exc()
-        self.logger.info(log_msg)
         return (
             f"{self.image_name}: {super().__str__()}\n"
             f"Check ({self.log_path}) for more information."

--- a/swebench/harness/run_evaluation.py
+++ b/swebench/harness/run_evaluation.py
@@ -26,6 +26,7 @@ from swebench.harness.docker_utils import (
     clean_images,
 )
 from swebench.harness.docker_build import (
+    BuildImageError,
     build_container,
     build_env_images,
     close_logger,
@@ -39,13 +40,14 @@ from swebench.harness.utils import load_swebench_dataset, str2bool
 class EvaluationError(Exception):
     def __init__(self, instance_id, message, logger):
         super().__init__(message)
+        self.super_str = super().__str__()
         self.instance_id = instance_id
         self.log_file = logger.log_file
         self.logger = logger
 
     def __str__(self):
         return (
-            f"{self.instance_id}: {super().__str__()}\n"
+            f"Evaluation error for {self.instance_id}: {self.super_str}\n"
             f"Check ({self.log_file}) for more information."
         )
 
@@ -147,7 +149,7 @@ def run_instance(
         eval_file = Path(log_dir / "eval.sh")
         eval_file.write_text(test_spec.eval_script)
         logger.info(
-            f"Eval script for {instance_id} written to {patch_file}, now applying to container..."
+            f"Eval script for {instance_id} written to {eval_file}; copying to container..."
         )
         copy_to_container(container, eval_file, Path("/eval.sh"))
 
@@ -161,14 +163,14 @@ def run_instance(
         logger.info(f'Test runtime: {total_runtime:_.2f} seconds')
         with open(test_output_path, "w") as f:
             f.write(test_output)
+            logger.info(f"Test output for {instance_id} written to {test_output_path}")
             if timed_out:
                 f.write(f"\n\nTimeout error: {timeout} seconds exceeded.")
                 raise EvaluationError(
                     instance_id,
-                    f"Timeout error: {timeout} seconds exceeded. See {test_output_path} for test output.",
+                    f"Test timed out after {timeout} seconds.",
                     logger,
                 )
-        logger.info(f"Test output for {instance_id} written to {test_output_path}")
 
         # Get git diff after running eval script
         git_diff_output_after = (
@@ -198,23 +200,26 @@ def run_instance(
             f.write(json.dumps(report, indent=4))
         return instance_id, report
     except EvaluationError as e:
-        error_msg = (f"EvaluationError {instance_id}: {e}\n"
-                     f"{traceback.format_exc()}\n"
-                     f"Check ({logger.log_file}) for more information.")
+        error_msg = traceback.format_exc()
         logger.info(error_msg)
-        print(error_msg)
+        print(e)
+    except BuildImageError as e:
+        error_msg = traceback.format_exc()
+        logger.info(error_msg)
+        print(e)
     except Exception as e:
         error_msg = (f"Error in evaluating model for {instance_id}: {e}\n"
                      f"{traceback.format_exc()}\n"
                      f"Check ({logger.log_file}) for more information.")
-        logger.info(error_msg)
-        print(error_msg)
+        logger.error(error_msg)
     finally:
         # Remove instance container + image, close logger
         cleanup_container(client, container, logger)
         if rm_image:
             remove_image(client, test_spec.instance_image_key, logger)
         close_logger(logger)
+    return
+
 
 def run_instances(
         predictions: dict,


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #160 

#### What does this implement/fix? Explain your changes.
Kills timed out test runs with kill -TERM in container.
Also improves logging and exception handling in for `run_instance` exceptions - including timeout.