### PR TITLE
fix: remove incorrect `exec_run` calls

### DIFF
--- a/swebench/harness/docker_utils.py
+++ b/swebench/harness/docker_utils.py
@@ -32,7 +32,7 @@ def copy_to_container(container: Container, src: Path, dst: Path):
     # temporary tar file
     tar_path = src.with_suffix(".tar")
     with tarfile.open(tar_path, "w") as tar:
-        tar.add(src, arcname=src.name)
+        tar.add(src, arcname=dst.name)  # use destination name, so after `put_archive`, name is correct
 
     # get bytes for put_archive cmd
     with open(tar_path, "rb") as tar_file:
@@ -43,11 +43,9 @@ def copy_to_container(container: Container, src: Path, dst: Path):
 
     # Send tar file to container and extract
     container.put_archive(os.path.dirname(dst), data)
-    container.exec_run(f"tar -xf {dst}.tar -C {dst.parent}")
 
     # clean up in locally and in container
     tar_path.unlink()
-    container.exec_run(f"rm {dst}.tar")
 
 
 def write_to_container(container: Container, data: str, dst: Path):


### PR DESCRIPTION
#### What does this implement/fix?

Remove some unnecessary/incorrect `exec_run` calls in `copy_too_container`.

According to the docker [documentation](https://docker-py.readthedocs.io/en/stable/containers.html), `put_archive` will “insert a file or folder in this container using a tar archive as source“. In other words, it does not simply copy the tar into the container. Instead, it will extract all the files in the tar directly to a destination in the container.

Therefore, we should remove unnecessary/incorrect calls to `tar` and `rm`.