### PR TITLE
Reimplementing validation script as part of dataset creation

### DIFF
--- a/swebench/collect/build_dataset.py
+++ b/swebench/collect/build_dataset.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 from typing import Optional
+from tqdm.auto import tqdm
 
 from swebench.collect.utils import (
     extract_patches,
@@ -142,7 +143,9 @@ def main(pr_file: str, output: str, token: Optional[str] = None):
         # Write to output file for PRs with test suites
         write_mode = "w" if not os.path.exists(output) else "a"
         with open(output, write_mode) as output:
-            for ix, line in enumerate(open(pr_file)):
+            with open(pr_file, 'r') as file:
+                total_lines = sum(1 for line in file)
+            for ix, line in tqdm(enumerate(open(pr_file)), total=total_lines):
                 total_instances += 1
                 pull = json.loads(line)
                 if ix % 100 == 0:

--- a/swebench/collect/collection.md
+++ b/swebench/collect/collection.md
@@ -47,7 +47,7 @@ Determining a version for each task instance can be accomplished in a number of 
 * Build from code: Sometimes, version-related files (i.e. `_version.py`) are purposely omitted by a developer (check `.gitignore` to verify). In this case, per task instance you can build the repository source code locally and extract the version number from the built codebase.
 
 Examples and technical details for each are included in `/versioning/`. Please refer to them as needed. Specifically, the 
-script `run_get_tasks_pipeline.sh` should be edited and run to assign versions to task instances. 
+script `run_get_versions.sh` should be edited and run to assign versions to task instances. 
 At this point you should have a `<repo name>-task-instances_versions.jsonl` file containing all the candidate task instances with versions.
 
 ### Part B: Installation Configurations

--- a/swebench/collect/collection.md
+++ b/swebench/collect/collection.md
@@ -46,7 +46,9 @@ Determining a version for each task instance can be accomplished in a number of 
 * Scrape from web: Repositories with websites (i.e. [xarray.dev](https://xarray.dev/)) have a "Releases" or "What's New" page (i.e. [release page](https://docs.xarray.dev/en/stable/whats-new.html) for xarray). This can be scraped for information.
 * Build from code: Sometimes, version-related files (i.e. `_version.py`) are purposely omitted by a developer (check `.gitignore` to verify). In this case, per task instance you can build the repository source code locally and extract the version number from the built codebase.
 
-Examples and technical details for each are included in `/versioning/`. Please refer to them as needed.
+Examples and technical details for each are included in `/versioning/`. Please refer to them as needed. Specifically, the 
+script `run_get_tasks_pipeline.sh` should be edited and run to assign versions to task instances. 
+At this point you should have a `<repo name>-task-instances_versions.jsonl` file containing all the candidate task instances with versions.
 
 ### Part B: Installation Configurations
 Per repository, you must provide installation instructions per version. In `constants.py`...
@@ -66,22 +68,11 @@ These instructions can typically be inferred from the companion website or `CONT
 Congrats, you got through the trickiest part! It's smooth sailing from here on out.
 
 We now need to check that the task instances install properly + the problem solved by the task instance is non-trivial.
-This is taken care of by the `engine_validation.py` code.
-Run `./harness/run_validation.sh` and supply the following arguments:
-* `instances_path`: Path to versioned candidate task instances
-* `log_dir`: Path to folder to store task instance-specific execution logs
-* `temp_dir`: Path to directory to perform execution
-* `verbose`: Whether to print logging traces to standard output.
+This is taken care of by the `run_validation.py` code.
+Run `./harness/run_validation.sh` script to execute the validation process. Make sure to edit the script with the appropriate arguments.
+
+The output of this script will be a `<repo name>-task-instances_versions_validated.jsonl` file containing all the validated task instances.
 
 > In practice, you may have to iterate between this step and **Installation Configurations** a couple times. If your instructions are incorrect/under-specified, it may result in candidate task instances not being installed properly.
-
-## 🔄 Convert to Task Instances
-At this point, we now have all the information necessary to determine if task instances can be used for evaluation with SWE-bench, and save them if they do.
-
-We provide the `validation.ipynb` Jupyter notebook provided in this folder to make the remaining steps easier.
-At a high level, it enables the following:
-* In **Monitor Validation**, check the results of the `./run_validation.sh` step.
-* In **Get [FP]2[FP] Tests**, determine which task instances are non-trivial (solves at least one test)
-* In **Create Task Instances `.json` file**, perform some final preprocessing and save your task instances to a `.json` file.
 
 Thanks for reading! If you have any questions or comments about the details in the article, please feel free to follow up with an issue.

--- a/swebench/harness/docker_build.py
+++ b/swebench/harness/docker_build.py
@@ -433,7 +433,7 @@ def build_instance_image(
     env_image_name = test_spec.env_image_key
     dockerfile = test_spec.instance_dockerfile
 
-    # Check that the env. image the instance image is based on exists
+    # Check that the env image the instance image is based on exists
     try:
         env_image = client.images.get(env_image_name)
     except docker.errors.ImageNotFound as e:

--- a/swebench/harness/grading.py
+++ b/swebench/harness/grading.py
@@ -31,7 +31,7 @@ def test_failed(case: str, sm: dict[str, str]) -> bool:
 
 
 # MARK: Evaluation report functions
-def get_logs_eval(log_fp: str) -> tuple[dict[str, str], bool]:
+def get_logs_eval(log_fp: str, test_output_fp: str) -> tuple[dict[str, str], bool]:
     """
     Retrieve evaluation results for a task instance from its corresponding log file
 
@@ -48,7 +48,7 @@ def get_logs_eval(log_fp: str) -> tuple[dict[str, str], bool]:
     repo = "-".join(sample_id.replace("__", "/").split("-")[:-1])  # e.g. scikit-learn/scikit-learn
     log_parser = MAP_REPO_TO_PARSER[repo]
 
-    with open(log_fp) as f:
+    with open(log_fp) as f, open(test_output_fp) as f2:
         content = f.read()
         # TODO fix constant here
         if (
@@ -64,14 +64,14 @@ def get_logs_eval(log_fp: str) -> tuple[dict[str, str], bool]:
                     ]
                 ]
             )
-            or "applied patch" not in content.lower()
+            or APPLY_PATCH_PASS not in content
         ):
             # Eval patch was not applied successfully
             return {}, False
 
         # Get status map of evaluation results
-        content = content.split(f"{APPLY_PATCH_PASS} (pred)")[-1]
-        return log_parser(content), True
+        test_content = f2.read()
+        return log_parser(test_content), True
 
 
 def get_eval_tests_report(
@@ -210,6 +210,7 @@ def get_eval_report(
     test_spec: TestSpec,
     prediction: dict[str, str],
     log_path: str,
+    test_output_path: str,
     include_tests_status: bool,
 ) -> dict[str, Any]:
     """
@@ -242,7 +243,7 @@ def get_eval_report(
     report_map[instance_id]["patch_exists"] = True
 
     # Get evaluation logs
-    eval_sm, found = get_logs_eval(log_path)
+    eval_sm, found = get_logs_eval(log_path, test_output_path)
 
     if not found:
         return report_map

--- a/swebench/harness/run_evaluation.py
+++ b/swebench/harness/run_evaluation.py
@@ -184,7 +184,8 @@ def run_instance(
         report = get_eval_report(
             test_spec=test_spec,
             prediction=pred,
-            log_path=test_output_path,
+            log_path=log_file,
+            test_output_path=test_output_path,
             include_tests_status=True,
         )
         logger.info(

--- a/swebench/harness/run_validation.py
+++ b/swebench/harness/run_validation.py
@@ -355,10 +355,13 @@ def main(
                 instance.update(results[instance_id])
                 
     last_dot_idx = dataset_name.rfind(".")   
-    dataset_name_w_results = dataset_name[:last_dot_idx] + "_results" + dataset_name[last_dot_idx:]
-    with open(dataset_name_w_results, "w") as f:
+    dataset_name_w_results_all = dataset_name[:last_dot_idx] + "_validated.all" + dataset_name[last_dot_idx:]
+    dataset_name_w_results = dataset_name[:last_dot_idx] + "_validated" + dataset_name[last_dot_idx:]
+    with open(dataset_name_w_results, "w") as f, open(dataset_name_w_results_all, "w") as f_all:
         for instance in data:
-            print(json.dumps(instance), file=f)
+            print(json.dumps(instance), file=f_all)
+            if len(instance["FAIL_TO_PASS"]) > 0:
+                print(json.dumps(instance), file=f)
 
 
 if __name__ == "__main__":

--- a/swebench/harness/run_validation.py
+++ b/swebench/harness/run_validation.py
@@ -14,7 +14,8 @@ from swebench.harness.constants import (
     APPLY_PATCH_FAIL,
     APPLY_PATCH_PASS,
     INSTANCE_IMAGE_BUILD_DIR,
-    RUN_INSTANCE_LOG_DIR,
+    KEY_INSTANCE_ID,
+    RUN_EVALUATION_LOG_DIR,
 )
 from swebench.harness.docker_utils import (
     remove_image,
@@ -31,25 +32,11 @@ from swebench.harness.docker_build import (
     close_logger,
     setup_logger,
 )
-from swebench.harness.grading import get_pred_report
+from swebench.harness.grading import get_eval_report
 from swebench.harness.test_spec import make_test_spec, TestSpec
 from swebench.harness.utils import load_swebench_dataset, str2bool
 from swebench.harness.grading import get_logs_eval   
-
-class EvaluationError(Exception):
-    def __init__(self, instance_id, message, logger):
-        super().__init__(message)
-        self.instance_id = instance_id
-        self.log_file = logger.log_file
-        self.logger = logger
-
-    def __str__(self):
-        log_msg = traceback.format_exc()
-        self.logger.info(log_msg)
-        return (
-            f"{self.instance_id}: {super().__str__()}\n"
-            f"Check ({self.log_file}) for more information."
-        )
+from swevench.harness.run_evaluation import get_gold_predictions, EvaluationError
 
 
 def run_instance(
@@ -59,7 +46,7 @@ def run_instance(
         force_rebuild: bool,
         client: docker.DockerClient,
         run_id: str,
-        timeout: int = None,
+        timeout: int | None = None,
     ):
     """
     Run a single instance with the given prediction.
@@ -76,7 +63,7 @@ def run_instance(
     # Set up logging directory
     instance_id = test_spec.instance_id
     model_name_or_path = pred.get("model_name_or_path", "None").replace("/", "__")
-    log_dir = RUN_INSTANCE_LOG_DIR / run_id / model_name_or_path / instance_id
+    log_dir = RUN_EVALUATION_LOG_DIR / run_id / model_name_or_path / instance_id
     log_dir.mkdir(parents=True, exist_ok=True)
 
     # Link the image build dir in the log dir
@@ -85,7 +72,7 @@ def run_instance(
     if not image_build_link.exists():
         try:
             # link the image build dir in the log dir
-            image_build_link.symlink_to(build_dir, target_is_directory=True)
+            image_build_link.symlink_to(build_dir.absolute(), target_is_directory=True)
         except:
             # some error, idk why
             pass
@@ -109,12 +96,19 @@ def run_instance(
         eval_file = Path(log_dir / "eval.sh")
         eval_file.write_text(test_spec.eval_script)
         copy_to_container(container, eval_file, Path("/eval.sh"))
-        result = exec_run_with_timeout(container, "/bin/bash /eval.sh", timeout=timeout)
-        test_output = result.decode("utf-8")
+        test_output, timed_out, total_runtime = exec_run_with_timeout(container, "/bin/bash /eval.sh", timeout)
         test_output_before_patch_path = log_dir / "test_output_before_patch.txt"
+        logger.info(f'Test runtime: {total_runtime:_.2f} seconds')
         with open(test_output_before_patch_path, "w") as f:
             f.write(test_output)
-        logger.info(f"Test output before patch for {instance_id} written to {test_output_before_patch_path}")
+            logger.info(f"Test output before patch for {instance_id} written to {test_output_before_patch_path}")
+            if timed_out:
+                f.write(f"\n\nTimeout error: {timeout} seconds exceeded.")
+                raise EvaluationError(
+                    instance_id,
+                    f"Test timed out after {timeout} seconds.",
+                    logger,
+                )
         
         # Copy model prediction as patch file to container
         patch_file = Path(log_dir / "patch.diff")
@@ -158,12 +152,19 @@ def run_instance(
         logger.info(f"Git diff before:\n{git_diff_output_before}")
 
         # Run eval script, write output to logs
-        result = exec_run_with_timeout(container, "/bin/bash /eval.sh", timeout=timeout)
-        test_output = result.decode("utf-8")
+        test_output, timed_out, total_runtime = exec_run_with_timeout(container, "/bin/bash /eval.sh", timeout)
         test_output_path = log_dir / "test_output.txt"
+        logger.info(f'Test runtime: {total_runtime:_.2f} seconds')
         with open(test_output_path, "w") as f:
             f.write(test_output)
-        logger.info(f"Test output for {instance_id} written to {test_output_path}")
+            logger.info(f"Test output for {instance_id} written to {test_output_path}")
+            if timed_out:
+                f.write(f"\n\nTimeout error: {timeout} seconds exceeded.")
+                raise EvaluationError(
+                    instance_id,
+                    f"Test timed out after {timeout} seconds.",
+                    logger,
+                )
 
         # Get git diff after running eval script
         git_diff_output_after = (
@@ -199,23 +200,26 @@ def run_instance(
                 
         return report_map
     except EvaluationError as e:
-        error_msg = (f"EvaluationError {instance_id}: {e}\n"
-                     f"{traceback.format_exc()}\n"
-                     f"Check ({logger.log_file}) for more information.")
+        error_msg = traceback.format_exc()
         logger.info(error_msg)
-        print(error_msg)
+        print(e)
+    except BuildImageError as e:
+        error_msg = traceback.format_exc()
+        logger.info(error_msg)
+        print(e)
     except Exception as e:
         error_msg = (f"Error in evaluating model for {instance_id}: {e}\n"
                      f"{traceback.format_exc()}\n"
                      f"Check ({logger.log_file}) for more information.")
-        logger.info(error_msg)
-        print(error_msg)
+        logger.error(error_msg)
     finally:
         # Remove instance container + image, close logger
         cleanup_container(client, container, logger)
         if rm_image:
             remove_image(client, test_spec.instance_image_key, logger)
         close_logger(logger)
+    return
+
 
 def run_instances(
         predictions: dict,
@@ -307,7 +311,7 @@ def get_dataset_from_preds(
     """
     # load dataset
     dataset = load_swebench_dataset(dataset_name, split)
-    dataset_ids = {i["instance_id"] for i in dataset}
+    dataset_ids = {i[KEY_INSTANCE_ID] for i in dataset}
 
     if instance_ids:
         # check that all instance IDs are in the dataset
@@ -336,166 +340,35 @@ def get_dataset_from_preds(
 
     if instance_ids:
         # filter dataset to just the instance IDs
-        dataset = [i for i in dataset if i["instance_id"] in instance_ids]
+        dataset = [i for i in dataset if i[KEY_INSTANCE_ID] in instance_ids]
 
     # check which instance IDs have already been run
     completed_ids = set()
     for instance in dataset:
-        if instance["instance_id"] not in prediction_ids:
+        if instance[KEY_INSTANCE_ID] not in prediction_ids:
             # skip instances without predictions
             continue
-        prediction = predictions[instance["instance_id"]]
+        prediction = predictions[instance[KEY_INSTANCE_ID]]
         report_file = (
-            RUN_INSTANCE_LOG_DIR
+            RUN_EVALUATION_LOG_DIR
             / run_id
             / prediction["model_name_or_path"].replace("/", "__")
-            / prediction["instance_id"]
+            / prediction[KEY_INSTANCE_ID]
             / "report.json"
         )
         if report_file.exists():
-            completed_ids.add(instance["instance_id"])
+            completed_ids.add(instance[KEY_INSTANCE_ID])
 
     if completed_ids and exclude_completed:
         # filter dataset to only instances that have not been run
         print(f"{len(completed_ids)} instances already run, skipping...")
-        dataset = [i for i in dataset if i["instance_id"] not in completed_ids]
+        dataset = [i for i in dataset if i[KEY_INSTANCE_ID] not in completed_ids]
 
     empty_patch_ids = {k for k, v in predictions.items() if v["model_patch"] == "" or v["model_patch"] is None}
 
     # filter dataset to only instances with predictions
-    dataset = [i for i in dataset if i["instance_id"] in prediction_ids and i["instance_id"] not in empty_patch_ids]
+    dataset = [i for i in dataset if i[KEY_INSTANCE_ID] in prediction_ids and i[KEY_INSTANCE_ID] not in empty_patch_ids]
     return dataset
-
-
-def make_run_report(
-        predictions: dict,
-        full_dataset: list,
-        client: docker.DockerClient,
-        run_id: str
-    ) -> Path:
-    """
-    Make a final evaluation and run report of the instances that have been run.
-    Also reports on images and containers that may still running!
-
-    Args:
-        predictions (dict): Predictions dict generated by the model
-        full_dataset (list): List of all instances
-        client (docker.DockerClient): Docker client
-        run_id (str): Run ID
-    
-    Returns:
-        Path to report file
-    """
-    # instantiate sets to store IDs of different outcomes
-    completed_ids = set()
-    resolved_ids = set()
-    error_ids = set()
-    unstopped_containers = set()
-    unremoved_images = set()
-    unresolved_ids = set()
-    incomplete_ids = set()
-    # get instances with empty patches
-    empty_patch_ids = set()
-
-    # iterate through dataset and check if the instance has been run
-    for instance in full_dataset:
-        instance_id = instance["instance_id"]
-        if instance_id not in predictions:
-            # skip instances without 
-            incomplete_ids.add(instance_id)
-            continue
-        prediction = predictions[instance_id]
-        if prediction.get("model_patch", None) in ["", None]:
-            empty_patch_ids.add(instance_id)
-            continue
-        report_file = (
-            RUN_INSTANCE_LOG_DIR
-            / run_id
-            / prediction["model_name_or_path"].replace("/", "__")
-            / prediction["instance_id"]
-            / "report.json"
-        )
-        if report_file.exists():
-            # If report file exists, then the instance has been run
-            completed_ids.add(instance_id)
-            report = json.loads(report_file.read_text())
-            if report[instance_id]["resolved"]:
-                # Record if the instance was resolved
-                resolved_ids.add(instance_id)
-            else:
-                unresolved_ids.add(instance_id)
-        else:
-            # Otherwise, the instance was not run successfully
-            error_ids.add(instance_id)
-
-    # get remaining images and containers
-    images = list_images(client)
-    test_specs = list(map(make_test_spec, full_dataset))
-    for spec in test_specs:
-        image_name = spec.instance_image_key
-        if image_name in images:
-            unremoved_images.add(image_name)
-    containers = client.containers.list(all=True)
-    for container in containers:
-        if run_id in container.name:
-            unstopped_containers.add(container.name)
-
-    # print final report
-    print(f"Total instances: {len(full_dataset)}")
-    print(f"Instances submitted: {len(predictions)}")
-    print(f"Instances completed: {len(completed_ids)}")
-    print(f"Instances incomplete: {len(incomplete_ids)}")
-    print(f"Instances resolved: {len(resolved_ids)}")
-    print(f"Instances unresolved: {len(unresolved_ids)}")
-    print(f"Instances with empty patches: {len(empty_patch_ids)}")
-    print(f"Instances with errors: {len(error_ids)}")
-    print(f"Unstopped containers: {len(unstopped_containers)}")
-    print(f"Unremoved images: {len(unremoved_images)}")
-
-    # write report to file
-    report = {
-        "total_instances": len(full_dataset),
-        "submitted_instances": len(predictions),
-        "completed_instances": len(completed_ids),
-        "resolved_instances": len(resolved_ids),
-        "unresolved_instances": len(unresolved_ids),
-        "empty_patch_instances": len(empty_patch_ids),
-        "error_instances": len(error_ids),
-        "unstopped_instances": len(unstopped_containers),
-        "completed_ids": list(sorted(completed_ids)),
-        "incomplete_ids": list(sorted(incomplete_ids)),
-        "empty_patch_ids": list(sorted(empty_patch_ids)),
-        "submitted_ids": list(sorted(predictions.keys())),
-        "resolved_ids": list(sorted(resolved_ids)),
-        "unresolved_ids": list(sorted(unresolved_ids)),
-        "error_ids": list(sorted(error_ids)),
-        "unstopped_containers": list(sorted(unstopped_containers)),
-        "unremoved_images": list(sorted(unremoved_images)),
-        "schema_version": 2,
-    }
-    report_file = Path(
-        list(predictions.values())[0]["model_name_or_path"].replace("/", "__")
-        + f".{run_id}"
-        + ".json"
-    )
-    with open(report_file, "w") as f:
-        print(json.dumps(report, indent=4), file=f)
-    print(f"Report written to {report_file}")
-    return report_file
-
-
-def get_gold_predictions(dataset_name: str, split: str):
-    """
-    Get gold predictions for the given dataset and split.
-    """
-    dataset = load_swebench_dataset(dataset_name, split)
-    return [
-        {
-            "instance_id": datum["instance_id"],
-            "model_patch": datum["patch"],
-            "model_name_or_path": "gold",
-        } for datum in dataset
-    ]
 
 
 def main(
@@ -520,7 +393,7 @@ def main(
 
     predictions = get_gold_predictions(dataset_name, split)
     
-    predictions = {pred["instance_id"]: pred for pred in predictions}
+    predictions = {pred[KEY_INSTANCE_ID]: pred for pred in predictions}
 
     # get dataset from predictions
     dataset = get_dataset_from_preds(dataset_name, split, instance_ids, predictions, run_id)

--- a/swebench/harness/run_validation.sh
+++ b/swebench/harness/run_validation.sh
@@ -1,0 +1,5 @@
+python run_validation.py \
+    --dataset_name <path to task instances with versions> \
+    --run_id <run id> \
+    --max_workers <number of workers> \
+    --cache_level <cache level>

--- a/swebench/harness/test_spec.py
+++ b/swebench/harness/test_spec.py
@@ -2,6 +2,7 @@ import hashlib
 import json
 import platform
 import re
+from tqdm.auto import tqdm
 
 from dataclasses import dataclass
 from typing import Any, Union, cast
@@ -112,7 +113,7 @@ def get_test_specs_from_dataset(dataset: Union[list[SWEbenchInstance], list[Test
     """
     if isinstance(dataset[0], TestSpec):
         return cast(list[TestSpec], dataset)
-    return list(map(make_test_spec, cast(list[SWEbenchInstance], dataset)))
+    return list(map(make_test_spec, cast(list[SWEbenchInstance], tqdm(dataset, desc="Converting instances"))))
 
 
 def make_repo_script_list(specs, repo, repo_directory, base_commit, env_name):

--- a/swebench/harness/utils.py
+++ b/swebench/harness/utils.py
@@ -29,7 +29,7 @@ def load_swebench_dataset(name="princeton-nlp/SWE-bench", split="test") -> list[
     if name.endswith(".json") or name.endswith(".jsonl"):
         return [
             cast(SWEbenchInstance, instance)
-            for instance in json.loads(Path(name).read_text())
+            for instance in json.loads(Path(name).read_text().split("\n").strip())
         ]
 
     # Load from Hugging Face Datasets

--- a/swebench/harness/utils.py
+++ b/swebench/harness/utils.py
@@ -28,8 +28,9 @@ def load_swebench_dataset(name="princeton-nlp/SWE-bench", split="test") -> list[
     # Load from local .json/.jsonl file
     if name.endswith(".json") or name.endswith(".jsonl"):
         return [
-            cast(SWEbenchInstance, instance)
-            for instance in json.loads(Path(name).read_text().split("\n").strip())
+            cast(SWEbenchInstance, json.loads(instance))
+            for instance in Path(name).read_text().split("\n")
+            if instance
         ]
 
     # Load from Hugging Face Datasets

--- a/swebench/versioning/get_versions.py
+++ b/swebench/versioning/get_versions.py
@@ -243,7 +243,9 @@ def merge_results(instances_path: str, repo_prefix: str, output_dir: str = None)
         output_dir = os.path.dirname(instances_path)
     instances_path_new = os.path.join(output_dir, instances_path_new)
     with open(f"{instances_path_new}", "w") as f:
-        json.dump(merged, fp=f)
+        for item in merged:
+            json.dump(item, f)
+            f.write('\n')
     logger.info(f"Saved merged results to {instances_path_new} ({len(merged)} instances)")
     return len(merged)
 


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #188

#### What does this implement/fix? Explain your changes.
This pull request recreates the flow that formerly existed in `engine_validation.py`. The primary functionality of this PR is to validate the tests gathered in previous steps to ensure they pass after applying the PR patch.

Key changes include:

- Introduction of `run_validation.py` script, which validates the PR gold patch using the PR tests.
- The script populates two lists in the JSON dataset: `FAIL_TO_PASS` and `PASS_TO_PASS`.
- Enhancements to various scripts to improve logging, error handling, and progress tracking using `tqdm`.
