### PR TITLE
Pin tox packages for sphinx images

### DIFF
--- a/swebench/harness/constants.py
+++ b/swebench/harness/constants.py
@@ -491,7 +491,7 @@ SPECS_MATPLOTLIB.update(
 SPECS_SPHINX = {
     k: {
         "python": "3.9",
-        "pip_packages": ["tox", "tox-current-env"],
+        "pip_packages": ["tox==4.16.0", "tox-current-env==0.0.11"],
         "install": "python -m pip install -e .[test]",
         "pre_install": ["sed -i 's/pytest/pytest -rA/' tox.ini"],
         "test_cmd": TEST_SPHINX,


### PR DESCRIPTION
When I rebuilt the sphinx images to test all SWE-Bench Verified instances all newly built images started to fail. Seems to be because of a new version of  `tox`. This PR is to pin the version in the previously built images. Which seems to work. 

Compare this benchmark run with failing sphinx instances:
https://eval.moatless.ai/evaluations/fcbb473f957149e7a5a45baeaa11800c

With this fix it looks like this:
https://eval.moatless.ai/evaluations/ab7a61b78e334a759fff3b344d30bd70

