### PR TITLE
avoid raising error when removing non-existent image

### DIFF
--- a/swebench/harness/docker_utils.py
+++ b/swebench/harness/docker_utils.py
@@ -84,11 +84,13 @@ def remove_image(client, image_id, logger=None):
         log_error = logger.info
         log_info = logger.info
         raise_error = False
-
     try:
         log_info(f"Attempting to remove image {image_id}...")
         client.images.remove(image_id, force=True)
         log_info(f"Image {image_id} removed.")
+    except docker.errors.ImageNotFound:
+        log_info(f"Image {image_id} not found, removing has no effect.")
+        log_info(f"Image {image_id} not found, removing has no effect.")
     except Exception as e:
         if raise_error:
             raise e

--- a/swebench/harness/docker_utils.py
+++ b/swebench/harness/docker_utils.py
@@ -90,7 +90,6 @@ def remove_image(client, image_id, logger=None):
         log_info(f"Image {image_id} removed.")
     except docker.errors.ImageNotFound:
         log_info(f"Image {image_id} not found, removing has no effect.")
-        log_info(f"Image {image_id} not found, removing has no effect.")
     except Exception as e:
         if raise_error:
             raise e


### PR DESCRIPTION
In `swebench/harness/docker_utils.py` sometimes, during cleaning, an image is marked for removal even if it doesn't exist (tbh not 100% why this happens), but when we try to remove a non-existent image, we get an error that interrupts execution.

There are currently no consequences to trying to remove a non-existent image, and the interruption is annoying, so we now should avoid throwing an error in those cases and instead just log the incident. We'll still get errors in other cases.