### PR TITLE
fix: sympy log parser fails to recognize the last test case

### DIFF
--- a/swebench/harness/log_parsers.py
+++ b/swebench/harness/log_parsers.py
@@ -203,6 +203,9 @@ def parse_log_sympy(log: str) -> dict[str, str]:
     for line in log.split("\n"):
         line = line.strip()
         if line.startswith("test_"):
+            if line.endswith("[FAIL]") or line.endswith("[OK]"):
+                line = line[: line.rfind("[")]
+                line = line.strip()
             if line.endswith(" E"):
                 test = line.split()[0]
                 test_status_map[test] = TestStatus.ERROR.value


### PR DESCRIPTION
#### What does this implement/fix?

Add additional checking and cleaning steps to the sympy log parser.

Previously, the sympy log parser could not parse the last line of the log file. For example, the following log (where `test_intersection_of_duplicate_sets` is a test I added manually):

```plaintext
...
test_issue_9447 ok
test_issue_10337 ok
test_issue_10326 ok
test_issue_2799 ok
test_issue_9706 ok
test_issue_8257 ok
test_issue_10931 ok
test_issue_11174 ok
test_finite_set_intersection ok
test_union_intersection_constructor ok
test_Union_contains ok
test_issue_16878b f
test_intersection_of_duplicate_sets F                                     [FAIL]
```

The current log parser will ignore the last line because there is a text `[FAIL]` (or `[OK]`) at the end of that line. This text will appear in the log when all the test functions in the file have been executed. This logic is in [`leaving_filename`](https://github.com/sympy/sympy/blob/f603be3941047d72e9acd23aa522a0323dfddf3f/sympy/utilities/runtests.py#L2266-L2274) function, which will be called at the end of the [`test_file`](https://github.com/sympy/sympy/blob/f603be3941047d72e9acd23aa522a0323dfddf3f/sympy/utilities/runtests.py#L1295) function.

To fix this, we can simply check to see if there is a `[FAIL]` or `[OK]` at the end of the line, and if there is, we can simply delete it and `strip` the `line` again.