### PR TITLE
Resolve an issue when attempting to call decode() on a streamed/potentially temporarily invalid utf-8 string.

### DIFF
--- a/swebench/harness/docker_utils.py
+++ b/swebench/harness/docker_utils.py
@@ -183,7 +183,7 @@ def exec_run_with_timeout(container, cmd, timeout: int|None=60):
         timeout (int): Timeout in seconds.
     """
     # Local variables to store the result of executing the command
-    exec_result = ''
+    exec_result = b''
     exec_id = None
     exception = None
     timed_out = False
@@ -195,7 +195,7 @@ def exec_run_with_timeout(container, cmd, timeout: int|None=60):
             exec_id = container.client.api.exec_create(container.id, cmd)["Id"]
             exec_stream = container.client.api.exec_start(exec_id, stream=True)
             for chunk in exec_stream:
-                exec_result += chunk.decode()
+                exec_result += chunk
         except Exception as e:
             exception = e
 
@@ -215,7 +215,7 @@ def exec_run_with_timeout(container, cmd, timeout: int|None=60):
             container.exec_run(f"kill -TERM {exec_pid}", detach=True)
         timed_out = True
     end_time = time.time()
-    return exec_result, timed_out, end_time - start_time
+    return exec_result.decode(), timed_out, end_time - start_time
 
 
 def find_dependent_images(client: docker.DockerClient, image_name: str):


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #215 

#### What does this implement/fix? Explain your changes.
Instead of accumulating the `exec_result` as the content is streamed back from the container as a utf-8 decoded string store it as bytes and decode only when returning the results.

#### Any other comments?
