### PR TITLE
fix docker building issues with sklearn

### DIFF
--- a/swebench/harness/constants.py
+++ b/swebench/harness/constants.py
@@ -75,7 +75,7 @@ SPECS_SKLEARN.update(
     {
         k: {
             "python": "3.9",
-            "packages": "numpy scipy cython setuptools pytest pandas matplotlib joblib threadpoolctl",
+            "packages": "'numpy==1.19.2' 'scipy==1.5.2' 'cython==3.0.10' pytest 'pandas<2.0.0' 'matplotlib<3.9.0' setuptools pytest joblib threadpoolctl",
             "install": "python -m pip install -v --no-use-pep517 --no-build-isolation -e .",
             "pip_packages": ["cython", "setuptools", "numpy", "scipy"],
             "test_cmd": TEST_PYTEST,


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #218 

#### What does this implement/fix? Explain your changes.
Fixes docker building issues for
- scikit-learn__scikit-learn-25973
- scikit-learn__scikit-learn-25747
- scikit-learn__scikit-learn-25102
- scikit-learn__scikit-learn-25931
- scikit-learn__scikit-learn-25232
- scikit-learn__scikit-learn-26194
- scikit-learn__scikit-learn-26323

Not all constraints might be necessary, but it should avoid more things to break in the future.