### PR TITLE
Pin Jinja2 to version <3.1 for Sphinx

### DIFF
--- a/swebench/harness/constants.py
+++ b/swebench/harness/constants.py
@@ -493,7 +493,7 @@ SPECS_MATPLOTLIB.update(
 SPECS_SPHINX = {
     k: {
         "python": "3.9",
-        "pip_packages": ["tox==4.16.0", "tox-current-env==0.0.11"],
+        "pip_packages": ["tox==4.16.0", "tox-current-env==0.0.11", "Jinja2<3.1"],
         "install": "python -m pip install -e .[test]",
         "pre_install": ["sed -i 's/pytest/pytest -rA/' tox.ini"],
         "test_cmd": TEST_SPHINX,


### PR DESCRIPTION
Fixes #241

Pin Jinja2 to version <3.1 for Sphinx in `swebench/harness/constants.py`.

* Add `Jinja2<3.1` to the `pip_packages` list for Sphinx in the `SPECS_SPHINX` dictionary.


Reference: https://www.ingap.dev/posts/solved-cannot-import-name-environmentfilter-from-jinja2

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/princeton-nlp/SWE-bench/issues/241?shareId=5cabb050-72d5-4ffa-a36d-1f6507abfd42).