### PR TITLE
Add extra validation for `make_run_report` to prevent Modal crash

### DIFF
--- a/swebench/harness/reporting.py
+++ b/swebench/harness/reporting.py
@@ -63,14 +63,22 @@ def make_run_report(
             / LOG_REPORT
         )
         if report_file.exists():
-            # If report file exists, then the instance has been run
             completed_ids.add(instance_id)
-            report = json.loads(report_file.read_text())
-            if report[instance_id]["resolved"]:
-                # Record if the instance was resolved
-                resolved_ids.add(instance_id)
-            else:
-                unresolved_ids.add(instance_id)
+            try:
+                content = report_file.read_text().strip()
+                if not content:  # Empty file
+                    error_ids.add(instance_id)
+                    continue
+                
+                report = json.loads(content)
+                if report[instance_id]["resolved"]:
+                    # Record if the instance was resolved
+                    resolved_ids.add(instance_id)
+                else:
+                    unresolved_ids.add(instance_id)
+            except (json.JSONDecodeError, KeyError):
+                # If the report file is not valid JSON or missing keys, treat as error
+                error_ids.add(instance_id)
         else:
             # Otherwise, the instance was not run successfully
             error_ids.add(instance_id)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!
-->

#### Reference Issues/PRs
<!--
Example: "Fixes #1234", "See also #3456"
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Explain your changes.
<!--
Please include a brief explanation of how your solution
fixes the tagged issue(s), along with what files / entities have
been modified for this fix.
-->

When using patch evaluation on Modal, I saw that sometimes the app crashed due to the error below:
```
Stopping app - uncaught exception raised locally: JSONDecodeError('Expecting value: line 1 column 1 (char 0)').
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/app/.venv/lib/python3.12/site-packages/swebench/harness/run_evaluation.py", line 619, in <module>
    main(**vars(args))
  File "/app/.venv/lib/python3.12/site-packages/swebench/harness/run_evaluation.py", line 496, in main
    run_instances_modal(predictions, dataset, full_dataset, run_id, timeout)
  File "/app/.venv/lib/python3.12/site-packages/swebench/harness/modal_eval/run_evaluation_modal.py", line 463, in run_instances_modal
    make_run_report(predictions, full_dataset, run_id)
  File "/app/.venv/lib/python3.12/site-packages/swebench/harness/reporting.py", line 68, in make_run_report
    report = json.loads(report_file.read_text())
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/json/decoder.py", line 338, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/json/decoder.py", line 356, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

Looking into the code, it seems the cause is that in `run_evaluation_modal.py`, the `open()` creates an empty file even when encountering an exception, which is then read by `make_run_report` and causes a crash due to invalid JSON:

https://github.com/SWE-bench/SWE-bench/blob/4b6773064a070c689874d30171e78a3f429a3fbf/swebench/harness/modal_eval/run_evaluation_modal.py#L454-L460

#### Any other comments?

<!-- 🧡 Thanks for contributing! -->
