### PR TITLE
Fix flaky java evals

### DIFF
--- a/swebench/harness/constants/java.py
+++ b/swebench/harness/constants/java.py
@@ -157,17 +157,17 @@ SPECS_GSON = {
         "install": ["mvn clean install -B -pl gson -DskipTests -am"],
         "test_cmd": [
             # FAIL_TO_PASS
-            "mvnd test -B -pl gson -Dtest=com.google.gson.functional.PrimitiveTest#testByteSerialization",
-            "mvnd test -B -pl gson -Dtest=com.google.gson.functional.PrimitiveTest#testShortSerialization",
-            "mvnd test -B -pl gson -Dtest=com.google.gson.functional.PrimitiveTest#testIntSerialization",
-            "mvnd test -B -pl gson -Dtest=com.google.gson.functional.PrimitiveTest#testLongSerialization",
-            "mvnd test -B -pl gson -Dtest=com.google.gson.functional.PrimitiveTest#testFloatSerialization",
-            "mvnd test -B -pl gson -Dtest=com.google.gson.functional.PrimitiveTest#testDoubleSerialization",
+            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.functional.PrimitiveTest#testByteSerialization",
+            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.functional.PrimitiveTest#testShortSerialization",
+            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.functional.PrimitiveTest#testIntSerialization",
+            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.functional.PrimitiveTest#testLongSerialization",
+            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.functional.PrimitiveTest#testFloatSerialization",
+            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.functional.PrimitiveTest#testDoubleSerialization",
             # PASS_TO_PASS
-            "mvnd test -B -pl gson -Dtest=com.google.gson.functional.PrimitiveTest#testPrimitiveIntegerAutoboxedSerialization",
-            "mvnd test -B -pl gson -Dtest=com.google.gson.functional.PrimitiveTest#testPrimitiveIntegerAutoboxedInASingleElementArraySerialization",
-            "mvnd test -B -pl gson -Dtest=com.google.gson.functional.PrimitiveTest#testReallyLongValuesSerialization",
-            "mvnd test -B -pl gson -Dtest=com.google.gson.functional.PrimitiveTest#testPrimitiveLongAutoboxedSerialization",
+            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.functional.PrimitiveTest#testPrimitiveIntegerAutoboxedSerialization",
+            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.functional.PrimitiveTest#testPrimitiveIntegerAutoboxedInASingleElementArraySerialization",
+            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.functional.PrimitiveTest#testReallyLongValuesSerialization",
+            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.functional.PrimitiveTest#testPrimitiveLongAutoboxedSerialization",
         ],
     },
     "2024": {
@@ -175,9 +175,9 @@ SPECS_GSON = {
         "install": ["mvn clean install -B -pl gson -DskipTests -am"],
         "test_cmd": [
             # FAIL_TO_PASS
-            "mvnd test -B -pl gson -Dtest=com.google.gson.functional.FieldNamingTest#testUpperCaseWithUnderscores",
-            "mvnd test -B -pl gson -Dtest=com.google.gson.functional.NamingPolicyTest#testGsonWithUpperCaseUnderscorePolicySerialization",
-            "mvnd test -B -pl gson -Dtest=com.google.gson.functional.NamingPolicyTest#testGsonWithUpperCaseUnderscorePolicyDeserialiation",
+            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.functional.FieldNamingTest#testUpperCaseWithUnderscores",
+            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.functional.NamingPolicyTest#testGsonWithUpperCaseUnderscorePolicySerialization",
+            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.functional.NamingPolicyTest#testGsonWithUpperCaseUnderscorePolicyDeserialiation",
         ],
     },
     "2479": {
@@ -185,10 +185,10 @@ SPECS_GSON = {
         "install": ["mvn clean install -B -pl gson -DskipTests -am"],
         "test_cmd": [
             # FAIL_TO_PASS
-            "mvnd test -B -pl gson -Dtest=com.google.gson.GsonBuilderTest#testRegisterTypeAdapterForObjectAndJsonElements",
-            "mvnd test -B -pl gson -Dtest=com.google.gson.GsonBuilderTest#testRegisterTypeHierarchyAdapterJsonElements",
+            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.GsonBuilderTest#testRegisterTypeAdapterForObjectAndJsonElements",
+            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.GsonBuilderTest#testRegisterTypeHierarchyAdapterJsonElements",
             # PASS_TO_PASS
-            "mvnd test -B -pl gson -Dtest=com.google.gson.GsonBuilderTest#testModificationAfterCreate",
+            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.GsonBuilderTest#testModificationAfterCreate",
         ],
     },
     "2134": {
@@ -196,10 +196,10 @@ SPECS_GSON = {
         "install": ["mvn clean install -B -pl gson -DskipTests -am"],
         "test_cmd": [
             # FAIL_TO_PASS
-            "mvnd test -B -pl gson -Dtest=com.google.gson.internal.bind.util.ISO8601UtilsTest#testDateParseInvalidDay",
-            "mvnd test -B -pl gson -Dtest=com.google.gson.internal.bind.util.ISO8601UtilsTest#testDateParseInvalidMonth",
+            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.internal.bind.util.ISO8601UtilsTest#testDateParseInvalidDay",
+            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.internal.bind.util.ISO8601UtilsTest#testDateParseInvalidMonth",
             # PASS_TO_PASS
-            "mvnd test -B -pl gson -Dtest=com.google.gson.internal.bind.util.ISO8601UtilsTest#testDateParseWithDefaultTimezone",
+            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.internal.bind.util.ISO8601UtilsTest#testDateParseWithDefaultTimezone",
         ],
     },
     "2061": {
@@ -207,13 +207,13 @@ SPECS_GSON = {
         "install": ["mvn clean install -B -pl gson -DskipTests -am"],
         "test_cmd": [
             # FAIL_TO_PASS
-            "mvnd test -B -pl gson -Dtest=com.google.gson.stream.JsonReaderTest#testHasNextEndOfDocument",
-            "mvnd test -B -pl gson -Dtest=com.google.gson.internal.bind.JsonTreeReaderTest#testHasNext_endOfDocument",
+            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.stream.JsonReaderTest#testHasNextEndOfDocument",
+            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.internal.bind.JsonTreeReaderTest#testHasNext_endOfDocument",
             # PASS_TO_PASS
-            "mvnd test -B -pl gson -Dtest=com.google.gson.stream.JsonReaderTest#testReadEmptyObject",
-            "mvnd test -B -pl gson -Dtest=com.google.gson.stream.JsonReaderTest#testReadEmptyArray",
-            "mvnd test -B -pl gson -Dtest=com.google.gson.internal.bind.JsonTreeReaderTest#testSkipValue_emptyJsonObject",
-            "mvnd test -B -pl gson -Dtest=com.google.gson.internal.bind.JsonTreeReaderTest#testSkipValue_filledJsonObject",
+            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.stream.JsonReaderTest#testReadEmptyObject",
+            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.stream.JsonReaderTest#testReadEmptyArray",
+            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.internal.bind.JsonTreeReaderTest#testSkipValue_emptyJsonObject",
+            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.internal.bind.JsonTreeReaderTest#testSkipValue_filledJsonObject",
         ],
     },
     "2311": {
@@ -221,10 +221,10 @@ SPECS_GSON = {
         "install": ["mvn clean install -B -pl gson -DskipTests -am"],
         "test_cmd": [
             # FAIL_TO_PASS
-            "mvnd test -B -pl gson -Dtest=com.google.gson.JsonPrimitiveTest#testEqualsIntegerAndBigInteger",
+            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.JsonPrimitiveTest#testEqualsIntegerAndBigInteger",
             # PASS_TO_PASS
-            "mvnd test -B -pl gson -Dtest=com.google.gson.JsonPrimitiveTest#testLongEqualsBigInteger",
-            "mvnd test -B -pl gson -Dtest=com.google.gson.JsonPrimitiveTest#testEqualsAcrossTypes",
+            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.JsonPrimitiveTest#testLongEqualsBigInteger",
+            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.JsonPrimitiveTest#testEqualsAcrossTypes",
         ],
     },
     "1100": {
@@ -232,10 +232,10 @@ SPECS_GSON = {
         "install": ["mvn clean install -B -pl gson -DskipTests -am"],
         "test_cmd": [
             # FAIL_TO_PASS
-            "mvnd test -B -pl gson -Dtest=com.google.gson.DefaultDateTypeAdapterTest#testNullValue",
+            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.DefaultDateTypeAdapterTest#testNullValue",
             # PASS_TO_PASS
-            "mvnd test -B -pl gson -Dtest=com.google.gson.DefaultDateTypeAdapterTest#testDatePattern",
-            "mvnd test -B -pl gson -Dtest=com.google.gson.DefaultDateTypeAdapterTest#testInvalidDatePattern",
+            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.DefaultDateTypeAdapterTest#testDatePattern",
+            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.DefaultDateTypeAdapterTest#testInvalidDatePattern",
         ],
     },
     "1093": {
@@ -243,12 +243,12 @@ SPECS_GSON = {
         "install": ["mvn clean install -B -pl gson -DskipTests -am"],
         "test_cmd": [
             # FAIL_TO_PASS
-            "mvnd test -B -pl gson -Dtest=com.google.gson.stream.JsonWriterTest#testNonFiniteDoublesWhenLenient",
+            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.stream.JsonWriterTest#testNonFiniteDoublesWhenLenient",
             # PASS_TO_PASS
-            "mvnd test -B -pl gson -Dtest=com.google.gson.stream.JsonWriterTest#testNonFiniteBoxedDoublesWhenLenient",
-            "mvnd test -B -pl gson -Dtest=com.google.gson.stream.JsonWriterTest#testNonFiniteDoubles",
-            "mvnd test -B -pl gson -Dtest=com.google.gson.stream.JsonWriterTest#testNonFiniteBoxedDoubles",
-            "mvnd test -B -pl gson -Dtest=com.google.gson.stream.JsonWriterTest#testDoubles",
+            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.stream.JsonWriterTest#testNonFiniteBoxedDoublesWhenLenient",
+            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.stream.JsonWriterTest#testNonFiniteDoubles",
+            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.stream.JsonWriterTest#testNonFiniteBoxedDoubles",
+            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.stream.JsonWriterTest#testDoubles",
         ],
     },
     "1014": {
@@ -256,8 +256,8 @@ SPECS_GSON = {
         "install": ["mvn clean install -B -pl gson -DskipTests -am"],
         "test_cmd": [
             # FAIL_TO_PASS
-            "mvnd test -B -pl gson -Dtest=com.google.gson.internal.bind.JsonTreeReaderTest#testSkipValue_emptyJsonObject",
-            "mvnd test -B -pl gson -Dtest=com.google.gson.internal.bind.JsonTreeReaderTest#testSkipValue_filledJsonObject",
+            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.internal.bind.JsonTreeReaderTest#testSkipValue_emptyJsonObject",
+            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.internal.bind.JsonTreeReaderTest#testSkipValue_filledJsonObject",
         ],
     },
 }
@@ -270,10 +270,10 @@ SPECS_DRUID = {
         ],
         "test_cmd": [
             # FAIL_TO_PASS
-            "mvnd test -B -pl processing -Dtest=org.apache.druid.query.groupby.GroupByQueryQueryToolChestTest#testCacheStrategy",
+            "mvnd test -B -T 1C -pl processing -Dtest=org.apache.druid.query.groupby.GroupByQueryQueryToolChestTest#testCacheStrategy",
             # PASS_TO_PASS
-            "mvnd test -B -pl processing -Dtest=org.apache.druid.query.groupby.GroupByQueryQueryToolChestTest#testResultLevelCacheKeyWithSubTotalsSpec",
-            "mvnd test -B -pl processing -Dtest=org.apache.druid.query.groupby.GroupByQueryQueryToolChestTest#testMultiColumnCacheStrategy",
+            "mvnd test -B -T 1C -pl processing -Dtest=org.apache.druid.query.groupby.GroupByQueryQueryToolChestTest#testResultLevelCacheKeyWithSubTotalsSpec",
+            "mvnd test -B -T 1C -pl processing -Dtest=org.apache.druid.query.groupby.GroupByQueryQueryToolChestTest#testMultiColumnCacheStrategy",
         ],
     },
     "14092": {
@@ -283,9 +283,9 @@ SPECS_DRUID = {
         ],
         "test_cmd": [
             # FAIL_TO_PASS
-            "mvnd test -B -pl server -Dtest=org.apache.druid.discovery.DruidLeaderClientTest#test503ResponseFromServerAndCacheRefresh",
+            "mvnd test -B -T 1C -pl server -Dtest=org.apache.druid.discovery.DruidLeaderClientTest#test503ResponseFromServerAndCacheRefresh",
             # PASS_TO_PASS
-            "mvnd test -B -pl server -Dtest=org.apache.druid.discovery.DruidLeaderClientTest#testServerFailureAndRedirect",
+            "mvnd test -B -T 1C -pl server -Dtest=org.apache.druid.discovery.DruidLeaderClientTest#testServerFailureAndRedirect",
         ],
     },
     "14136": {
@@ -295,13 +295,13 @@ SPECS_DRUID = {
         ],
         "test_cmd": [
             # FAIL_TO_PASS
-            "mvnd test -B -pl processing -Dtest=org.apache.druid.timeline.VersionedIntervalTimelineTest#testOverlapSecondContainsFirstZeroLengthInterval",
-            "mvnd test -B -pl processing -Dtest=org.apache.druid.timeline.VersionedIntervalTimelineTest#testOverlapSecondContainsFirstZeroLengthInterval2",
-            "mvnd test -B -pl processing -Dtest=org.apache.druid.timeline.VersionedIntervalTimelineTest#testOverlapSecondContainsFirstZeroLengthInterval3",
-            "mvnd test -B -pl processing -Dtest=org.apache.druid.timeline.VersionedIntervalTimelineTest#testOverlapSecondContainsFirstZeroLengthInterval4",
+            "mvnd test -B -T 1C -pl processing -Dtest=org.apache.druid.timeline.VersionedIntervalTimelineTest#testOverlapSecondContainsFirstZeroLengthInterval",
+            "mvnd test -B -T 1C -pl processing -Dtest=org.apache.druid.timeline.VersionedIntervalTimelineTest#testOverlapSecondContainsFirstZeroLengthInterval2",
+            "mvnd test -B -T 1C -pl processing -Dtest=org.apache.druid.timeline.VersionedIntervalTimelineTest#testOverlapSecondContainsFirstZeroLengthInterval3",
+            "mvnd test -B -T 1C -pl processing -Dtest=org.apache.druid.timeline.VersionedIntervalTimelineTest#testOverlapSecondContainsFirstZeroLengthInterval4",
             # PASS_TO_PASS
-            "mvnd test -B -pl processing -Dtest=org.apache.druid.timeline.VersionedIntervalTimelineTest#testOverlapFirstContainsSecond",
-            "mvnd test -B -pl processing -Dtest=org.apache.druid.timeline.VersionedIntervalTimelineTest#testOverlapSecondContainsFirst",
+            "mvnd test -B -T 1C -pl processing -Dtest=org.apache.druid.timeline.VersionedIntervalTimelineTest#testOverlapFirstContainsSecond",
+            "mvnd test -B -T 1C -pl processing -Dtest=org.apache.druid.timeline.VersionedIntervalTimelineTest#testOverlapSecondContainsFirst",
         ],
     },
     "13704": {

--- a/swebench/harness/constants/java.py
+++ b/swebench/harness/constants/java.py
@@ -157,17 +157,17 @@ SPECS_GSON = {
         "install": ["mvn clean install -B -pl gson -DskipTests -am"],
         "test_cmd": [
             # FAIL_TO_PASS
-            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.functional.PrimitiveTest#testByteSerialization",
-            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.functional.PrimitiveTest#testShortSerialization",
-            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.functional.PrimitiveTest#testIntSerialization",
-            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.functional.PrimitiveTest#testLongSerialization",
-            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.functional.PrimitiveTest#testFloatSerialization",
-            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.functional.PrimitiveTest#testDoubleSerialization",
+            "mvnd test -B -pl gson -Dtest=com.google.gson.functional.PrimitiveTest#testByteSerialization",
+            "mvnd test -B -pl gson -Dtest=com.google.gson.functional.PrimitiveTest#testShortSerialization",
+            "mvnd test -B -pl gson -Dtest=com.google.gson.functional.PrimitiveTest#testIntSerialization",
+            "mvnd test -B -pl gson -Dtest=com.google.gson.functional.PrimitiveTest#testLongSerialization",
+            "mvnd test -B -pl gson -Dtest=com.google.gson.functional.PrimitiveTest#testFloatSerialization",
+            "mvnd test -B -pl gson -Dtest=com.google.gson.functional.PrimitiveTest#testDoubleSerialization",
             # PASS_TO_PASS
-            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.functional.PrimitiveTest#testPrimitiveIntegerAutoboxedSerialization",
-            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.functional.PrimitiveTest#testPrimitiveIntegerAutoboxedInASingleElementArraySerialization",
-            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.functional.PrimitiveTest#testReallyLongValuesSerialization",
-            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.functional.PrimitiveTest#testPrimitiveLongAutoboxedSerialization",
+            "mvnd test -B -pl gson -Dtest=com.google.gson.functional.PrimitiveTest#testPrimitiveIntegerAutoboxedSerialization",
+            "mvnd test -B -pl gson -Dtest=com.google.gson.functional.PrimitiveTest#testPrimitiveIntegerAutoboxedInASingleElementArraySerialization",
+            "mvnd test -B -pl gson -Dtest=com.google.gson.functional.PrimitiveTest#testReallyLongValuesSerialization",
+            "mvnd test -B -pl gson -Dtest=com.google.gson.functional.PrimitiveTest#testPrimitiveLongAutoboxedSerialization",
         ],
     },
     "2024": {
@@ -175,9 +175,9 @@ SPECS_GSON = {
         "install": ["mvn clean install -B -pl gson -DskipTests -am"],
         "test_cmd": [
             # FAIL_TO_PASS
-            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.functional.FieldNamingTest#testUpperCaseWithUnderscores",
-            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.functional.NamingPolicyTest#testGsonWithUpperCaseUnderscorePolicySerialization",
-            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.functional.NamingPolicyTest#testGsonWithUpperCaseUnderscorePolicyDeserialiation",
+            "mvnd test -B -pl gson -Dtest=com.google.gson.functional.FieldNamingTest#testUpperCaseWithUnderscores",
+            "mvnd test -B -pl gson -Dtest=com.google.gson.functional.NamingPolicyTest#testGsonWithUpperCaseUnderscorePolicySerialization",
+            "mvnd test -B -pl gson -Dtest=com.google.gson.functional.NamingPolicyTest#testGsonWithUpperCaseUnderscorePolicyDeserialiation",
         ],
     },
     "2479": {
@@ -185,10 +185,10 @@ SPECS_GSON = {
         "install": ["mvn clean install -B -pl gson -DskipTests -am"],
         "test_cmd": [
             # FAIL_TO_PASS
-            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.GsonBuilderTest#testRegisterTypeAdapterForObjectAndJsonElements",
-            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.GsonBuilderTest#testRegisterTypeHierarchyAdapterJsonElements",
+            "mvnd test -B -pl gson -Dtest=com.google.gson.GsonBuilderTest#testRegisterTypeAdapterForObjectAndJsonElements",
+            "mvnd test -B -pl gson -Dtest=com.google.gson.GsonBuilderTest#testRegisterTypeHierarchyAdapterJsonElements",
             # PASS_TO_PASS
-            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.GsonBuilderTest#testModificationAfterCreate",
+            "mvnd test -B -pl gson -Dtest=com.google.gson.GsonBuilderTest#testModificationAfterCreate",
         ],
     },
     "2134": {
@@ -196,10 +196,10 @@ SPECS_GSON = {
         "install": ["mvn clean install -B -pl gson -DskipTests -am"],
         "test_cmd": [
             # FAIL_TO_PASS
-            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.internal.bind.util.ISO8601UtilsTest#testDateParseInvalidDay",
-            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.internal.bind.util.ISO8601UtilsTest#testDateParseInvalidMonth",
+            "mvnd test -B -pl gson -Dtest=com.google.gson.internal.bind.util.ISO8601UtilsTest#testDateParseInvalidDay",
+            "mvnd test -B -pl gson -Dtest=com.google.gson.internal.bind.util.ISO8601UtilsTest#testDateParseInvalidMonth",
             # PASS_TO_PASS
-            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.internal.bind.util.ISO8601UtilsTest#testDateParseWithDefaultTimezone",
+            "mvnd test -B -pl gson -Dtest=com.google.gson.internal.bind.util.ISO8601UtilsTest#testDateParseWithDefaultTimezone",
         ],
     },
     "2061": {
@@ -207,13 +207,13 @@ SPECS_GSON = {
         "install": ["mvn clean install -B -pl gson -DskipTests -am"],
         "test_cmd": [
             # FAIL_TO_PASS
-            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.stream.JsonReaderTest#testHasNextEndOfDocument",
-            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.internal.bind.JsonTreeReaderTest#testHasNext_endOfDocument",
+            "mvnd test -B -pl gson -Dtest=com.google.gson.stream.JsonReaderTest#testHasNextEndOfDocument",
+            "mvnd test -B -pl gson -Dtest=com.google.gson.internal.bind.JsonTreeReaderTest#testHasNext_endOfDocument",
             # PASS_TO_PASS
-            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.stream.JsonReaderTest#testReadEmptyObject",
-            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.stream.JsonReaderTest#testReadEmptyArray",
-            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.internal.bind.JsonTreeReaderTest#testSkipValue_emptyJsonObject",
-            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.internal.bind.JsonTreeReaderTest#testSkipValue_filledJsonObject",
+            "mvnd test -B -pl gson -Dtest=com.google.gson.stream.JsonReaderTest#testReadEmptyObject",
+            "mvnd test -B -pl gson -Dtest=com.google.gson.stream.JsonReaderTest#testReadEmptyArray",
+            "mvnd test -B -pl gson -Dtest=com.google.gson.internal.bind.JsonTreeReaderTest#testSkipValue_emptyJsonObject",
+            "mvnd test -B -pl gson -Dtest=com.google.gson.internal.bind.JsonTreeReaderTest#testSkipValue_filledJsonObject",
         ],
     },
     "2311": {
@@ -221,10 +221,10 @@ SPECS_GSON = {
         "install": ["mvn clean install -B -pl gson -DskipTests -am"],
         "test_cmd": [
             # FAIL_TO_PASS
-            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.JsonPrimitiveTest#testEqualsIntegerAndBigInteger",
+            "mvnd test -B -pl gson -Dtest=com.google.gson.JsonPrimitiveTest#testEqualsIntegerAndBigInteger",
             # PASS_TO_PASS
-            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.JsonPrimitiveTest#testLongEqualsBigInteger",
-            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.JsonPrimitiveTest#testEqualsAcrossTypes",
+            "mvnd test -B -pl gson -Dtest=com.google.gson.JsonPrimitiveTest#testLongEqualsBigInteger",
+            "mvnd test -B -pl gson -Dtest=com.google.gson.JsonPrimitiveTest#testEqualsAcrossTypes",
         ],
     },
     "1100": {
@@ -232,10 +232,10 @@ SPECS_GSON = {
         "install": ["mvn clean install -B -pl gson -DskipTests -am"],
         "test_cmd": [
             # FAIL_TO_PASS
-            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.DefaultDateTypeAdapterTest#testNullValue",
+            "mvnd test -B -pl gson -Dtest=com.google.gson.DefaultDateTypeAdapterTest#testNullValue",
             # PASS_TO_PASS
-            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.DefaultDateTypeAdapterTest#testDatePattern",
-            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.DefaultDateTypeAdapterTest#testInvalidDatePattern",
+            "mvnd test -B -pl gson -Dtest=com.google.gson.DefaultDateTypeAdapterTest#testDatePattern",
+            "mvnd test -B -pl gson -Dtest=com.google.gson.DefaultDateTypeAdapterTest#testInvalidDatePattern",
         ],
     },
     "1093": {
@@ -243,12 +243,12 @@ SPECS_GSON = {
         "install": ["mvn clean install -B -pl gson -DskipTests -am"],
         "test_cmd": [
             # FAIL_TO_PASS
-            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.stream.JsonWriterTest#testNonFiniteDoublesWhenLenient",
+            "mvnd test -B -pl gson -Dtest=com.google.gson.stream.JsonWriterTest#testNonFiniteDoublesWhenLenient",
             # PASS_TO_PASS
-            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.stream.JsonWriterTest#testNonFiniteBoxedDoublesWhenLenient",
-            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.stream.JsonWriterTest#testNonFiniteDoubles",
-            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.stream.JsonWriterTest#testNonFiniteBoxedDoubles",
-            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.stream.JsonWriterTest#testDoubles",
+            "mvnd test -B -pl gson -Dtest=com.google.gson.stream.JsonWriterTest#testNonFiniteBoxedDoublesWhenLenient",
+            "mvnd test -B -pl gson -Dtest=com.google.gson.stream.JsonWriterTest#testNonFiniteDoubles",
+            "mvnd test -B -pl gson -Dtest=com.google.gson.stream.JsonWriterTest#testNonFiniteBoxedDoubles",
+            "mvnd test -B -pl gson -Dtest=com.google.gson.stream.JsonWriterTest#testDoubles",
         ],
     },
     "1014": {
@@ -256,8 +256,8 @@ SPECS_GSON = {
         "install": ["mvn clean install -B -pl gson -DskipTests -am"],
         "test_cmd": [
             # FAIL_TO_PASS
-            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.internal.bind.JsonTreeReaderTest#testSkipValue_emptyJsonObject",
-            "mvnd test -B -T 1C -pl gson -Dtest=com.google.gson.internal.bind.JsonTreeReaderTest#testSkipValue_filledJsonObject",
+            "mvnd test -B -pl gson -Dtest=com.google.gson.internal.bind.JsonTreeReaderTest#testSkipValue_emptyJsonObject",
+            "mvnd test -B -pl gson -Dtest=com.google.gson.internal.bind.JsonTreeReaderTest#testSkipValue_filledJsonObject",
         ],
     },
 }
@@ -270,10 +270,10 @@ SPECS_DRUID = {
         ],
         "test_cmd": [
             # FAIL_TO_PASS
-            "mvnd test -B -T 1C -pl processing -Dtest=org.apache.druid.query.groupby.GroupByQueryQueryToolChestTest#testCacheStrategy",
+            "mvnd test -B -pl processing -Dtest=org.apache.druid.query.groupby.GroupByQueryQueryToolChestTest#testCacheStrategy",
             # PASS_TO_PASS
-            "mvnd test -B -T 1C -pl processing -Dtest=org.apache.druid.query.groupby.GroupByQueryQueryToolChestTest#testResultLevelCacheKeyWithSubTotalsSpec",
-            "mvnd test -B -T 1C -pl processing -Dtest=org.apache.druid.query.groupby.GroupByQueryQueryToolChestTest#testMultiColumnCacheStrategy",
+            "mvnd test -B -pl processing -Dtest=org.apache.druid.query.groupby.GroupByQueryQueryToolChestTest#testResultLevelCacheKeyWithSubTotalsSpec",
+            "mvnd test -B -pl processing -Dtest=org.apache.druid.query.groupby.GroupByQueryQueryToolChestTest#testMultiColumnCacheStrategy",
         ],
     },
     "14092": {
@@ -283,9 +283,9 @@ SPECS_DRUID = {
         ],
         "test_cmd": [
             # FAIL_TO_PASS
-            "mvnd test -B -T 1C -pl server -Dtest=org.apache.druid.discovery.DruidLeaderClientTest#test503ResponseFromServerAndCacheRefresh",
+            "mvnd test -B -pl server -Dtest=org.apache.druid.discovery.DruidLeaderClientTest#test503ResponseFromServerAndCacheRefresh",
             # PASS_TO_PASS
-            "mvnd test -B -T 1C -pl server -Dtest=org.apache.druid.discovery.DruidLeaderClientTest#testServerFailureAndRedirect",
+            "mvnd test -B -pl server -Dtest=org.apache.druid.discovery.DruidLeaderClientTest#testServerFailureAndRedirect",
         ],
     },
     "14136": {
@@ -295,13 +295,13 @@ SPECS_DRUID = {
         ],
         "test_cmd": [
             # FAIL_TO_PASS
-            "mvnd test -B -T 1C -pl processing -Dtest=org.apache.druid.timeline.VersionedIntervalTimelineTest#testOverlapSecondContainsFirstZeroLengthInterval",
-            "mvnd test -B -T 1C -pl processing -Dtest=org.apache.druid.timeline.VersionedIntervalTimelineTest#testOverlapSecondContainsFirstZeroLengthInterval2",
-            "mvnd test -B -T 1C -pl processing -Dtest=org.apache.druid.timeline.VersionedIntervalTimelineTest#testOverlapSecondContainsFirstZeroLengthInterval3",
-            "mvnd test -B -T 1C -pl processing -Dtest=org.apache.druid.timeline.VersionedIntervalTimelineTest#testOverlapSecondContainsFirstZeroLengthInterval4",
+            "mvnd test -B -pl processing -Dtest=org.apache.druid.timeline.VersionedIntervalTimelineTest#testOverlapSecondContainsFirstZeroLengthInterval",
+            "mvnd test -B -pl processing -Dtest=org.apache.druid.timeline.VersionedIntervalTimelineTest#testOverlapSecondContainsFirstZeroLengthInterval2",
+            "mvnd test -B -pl processing -Dtest=org.apache.druid.timeline.VersionedIntervalTimelineTest#testOverlapSecondContainsFirstZeroLengthInterval3",
+            "mvnd test -B -pl processing -Dtest=org.apache.druid.timeline.VersionedIntervalTimelineTest#testOverlapSecondContainsFirstZeroLengthInterval4",
             # PASS_TO_PASS
-            "mvnd test -B -T 1C -pl processing -Dtest=org.apache.druid.timeline.VersionedIntervalTimelineTest#testOverlapFirstContainsSecond",
-            "mvnd test -B -T 1C -pl processing -Dtest=org.apache.druid.timeline.VersionedIntervalTimelineTest#testOverlapSecondContainsFirst",
+            "mvnd test -B -pl processing -Dtest=org.apache.druid.timeline.VersionedIntervalTimelineTest#testOverlapFirstContainsSecond",
+            "mvnd test -B -pl processing -Dtest=org.apache.druid.timeline.VersionedIntervalTimelineTest#testOverlapSecondContainsFirst",
         ],
     },
     "13704": {

--- a/tests/test_log_parsers_java.py
+++ b/tests/test_log_parsers_java.py
@@ -75,3 +75,18 @@ class TestParseLogMaven:
         assert result["com.example.Test#testOne"] == TestStatus.PASSED.value
         assert result["com.example.Test#testTwo"] == TestStatus.PASSED.value
         assert result["com.example.Test#testThree"] == TestStatus.FAILED.value
+
+    def test_delayed_build_result_after_marker(self):
+        """Test when BUILD SUCCESS appears after end marker due to buffering."""
+        log = """+ mvnd test -B -Dtest=com.example.Test#testOne
+[INFO] BUILD SUCCESS
++ mvnd test -B -Dtest=com.example.Test#testTwo
++ : '>>>>> End Test Output'
++ git checkout somefile.java
+[INFO] BUILD SUCCESS
+"""
+        result = parse_log_maven(log, test_spec=None)
+
+        assert len(result) == 2
+        assert result["com.example.Test#testOne"] == TestStatus.PASSED.value
+        assert result["com.example.Test#testTwo"] == TestStatus.PASSED.value

--- a/tests/test_log_parsers_java.py
+++ b/tests/test_log_parsers_java.py
@@ -1,0 +1,44 @@
+from swebench.harness.log_parsers.java import parse_log_gradle_custom
+from swebench.harness.constants import TestStatus
+
+
+class TestParseLogGradleCustom:
+    """Tests for parse_log_gradle_custom used by Apache Lucene and RxJava."""
+
+    def test_parse_pass_and_fail(self):
+        """Test parsing normal output with passing and failing tests."""
+        log = """com.example.Test > testOne PASSED
+com.example.Test > testTwo FAILED
+"""
+        result = parse_log_gradle_custom(log, test_spec=None)
+
+        assert len(result) == 2
+        assert result["com.example.Test > testOne"] == TestStatus.PASSED.value
+        assert result["com.example.Test > testTwo"] == TestStatus.FAILED.value
+
+    def test_ignores_non_test_lines(self):
+        """Test that task lines and other noise are ignored."""
+        log = """> Task :test
+WARNING: Some warning
+com.example.Test > testMethod PASSED
+BUILD SUCCESSFUL
+"""
+        result = parse_log_gradle_custom(log, test_spec=None)
+
+        assert result == {"com.example.Test > testMethod": TestStatus.PASSED.value}
+
+    def test_interleaved_logs_race_condition(self):
+        """Test parsing when warnings split test name from status."""
+        log = """com.example.Test > testOne PASSED
+com.example.Test > testTwo
+WARNING: interleaved output
+PASSED
+com.example.Test > testThree
+FAILED
+"""
+        result = parse_log_gradle_custom(log, test_spec=None)
+
+        assert len(result) == 3
+        assert result["com.example.Test > testOne"] == TestStatus.PASSED.value
+        assert result["com.example.Test > testTwo"] == TestStatus.PASSED.value
+        assert result["com.example.Test > testThree"] == TestStatus.FAILED.value


### PR DESCRIPTION
## Problem

Java evaluations were producing inconsistent results due to race conditions in log parsing. When running tests with set -x shell tracing enabled, concurrent output from Maven/Gradle and shell tracing can interleave, breaking the assumption that test commands and their results appear sequentially.

## Changes

Maven log parser (parse_log_maven)

- Added a queue-based approach (pending_tests) to handle cases where multiple -Dtest= commands appear before their BUILD SUCCESS/FAILURE results
- Matches test commands to results in FIFO order

Gradle log parser (parse_log_gradle_custom)

- Added handling for split output where test name (e.g., com.example.Test > testMethod) and status (PASSED/FAILED) appear on separate lines
- Tracks pending_test_name to match standalone status lines back to their test

## Testing

Added test cases in tests/test_log_parsers_java.py covering:

- Normal sequential output (existing behavior)
- Interleaved/concurrent output scenarios