### PR TITLE
Add SWE-bench Pro spec fallback + initial Pro repo support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,9 @@ include-package-data = true
 [tool.setuptools.dynamic]
 version = {attr = "swebench.__version__"}
 
+[tool.setuptools.package-data]
+"swebench.harness.constants" = ["fixtures/*.Cargo.lock"]
+
 [tool.setuptools.packages.find]
 where = ["."]
 namespaces = false

--- a/swebench/harness/constants/go.py
+++ b/swebench/harness/constants/go.py
@@ -233,6 +233,38 @@ SPECS_GIN = {
     },
 }
 
+SPECS_FLIPT_PRO = {
+    "default": {
+        "docker_specs": {"go_version": "1.23.8"},
+        "install": ["go mod download"],
+        "test_cmd": "go test -v ./...",
+    }
+}
+
+SPECS_VULS_PRO = {
+    "default": {
+        "docker_specs": {"go_version": "1.23.8"},
+        "install": ["go mod download"],
+        "test_cmd": "go test -v ./...",
+    }
+}
+
+SPECS_TELEPORT_PRO = {
+    "default": {
+        "docker_specs": {"go_version": "1.23.8"},
+        "install": ["go mod download"],
+        "test_cmd": "go test -v ./...",
+    }
+}
+
+SPECS_NAVIDROME_PRO = {
+    "default": {
+        "docker_specs": {"go_version": "1.23.8"},
+        "install": ["go mod download"],
+        "test_cmd": "go test -v ./...",
+    }
+}
+
 
 MAP_REPO_VERSION_TO_SPECS_GO = {
     "caddyserver/caddy": SPECS_CADDY,
@@ -240,6 +272,10 @@ MAP_REPO_VERSION_TO_SPECS_GO = {
     "prometheus/prometheus": SPECS_PROMETHEUS,
     "gohugoio/hugo": SPECS_HUGO,
     "gin-gonic/gin": SPECS_GIN,
+    "flipt-io/flipt": SPECS_FLIPT_PRO,
+    "future-architect/vuls": SPECS_VULS_PRO,
+    "gravitational/teleport": SPECS_TELEPORT_PRO,
+    "navidrome/navidrome": SPECS_NAVIDROME_PRO,
 }
 
 # Constants - Repository Specific Installation Instructions

--- a/swebench/harness/constants/javascript.py
+++ b/swebench/harness/constants/javascript.py
@@ -556,6 +556,56 @@ SPECS_AXIOS = {
     },
 }
 
+SPECS_NODEBB_PRO = {
+    "default": {
+        "install": [
+            "if [ -f package-lock.json ]; then npm ci; else npm install; fi",
+        ],
+        "test_cmd": "npx mocha --exit",
+        "docker_specs": {
+            "node_version": "20.16.0",
+        },
+    }
+}
+
+SPECS_ELEMENT_WEB_PRO = {
+    "default": {
+        "install": [
+            "npm install -g yarn",
+            "yarn install --frozen-lockfile || yarn install",
+        ],
+        "test_cmd": "npx jest --runInBand --verbose",
+        "docker_specs": {
+            "node_version": "20.16.0",
+        },
+    }
+}
+
+SPECS_PROTONMAIL_WEBCLIENTS_PRO = {
+    "default": {
+        "install": [
+            "npm install -g yarn",
+            "yarn install --frozen-lockfile || yarn install",
+        ],
+        "test_cmd": "npx jest --runInBand --verbose",
+        "docker_specs": {
+            "node_version": "20.16.0",
+        },
+    }
+}
+
+SPECS_TUTANOTA_PRO = {
+    "default": {
+        "install": [
+            "if [ -f package-lock.json ]; then npm ci; else npm install; fi",
+        ],
+        "test_cmd": "npx jest --runInBand --verbose",
+        "docker_specs": {
+            "node_version": "20.16.0",
+        },
+    }
+}
+
 
 MAP_REPO_VERSION_TO_SPECS_JS = {
     "Automattic/wp-calypso": SPECS_CALYPSO,
@@ -570,6 +620,10 @@ MAP_REPO_VERSION_TO_SPECS_JS = {
     "mrdoob/three.js": SPECS_THREEJS,
     "preactjs/preact": SPECS_PREACT,
     "axios/axios": SPECS_AXIOS,
+    "NodeBB/NodeBB": SPECS_NODEBB_PRO,
+    "element-hq/element-web": SPECS_ELEMENT_WEB_PRO,
+    "protonmail/webclients": SPECS_PROTONMAIL_WEBCLIENTS_PRO,
+    "tutao/tutanota": SPECS_TUTANOTA_PRO,
 }
 
 # Constants - Repository Specific Installation Instructions

--- a/swebench/harness/constants/python.py
+++ b/swebench/harness/constants/python.py
@@ -902,6 +902,33 @@ SPECS_PYDICOM.update(
 
 SPECS_HUMANEVAL = {k: {"python": "3.9", "test_cmd": "python"} for k in ["1.0"]}
 
+SPECS_ANSIBLE_PRO = {
+    "default": {
+        "python": "3.11",
+        "install": "python -m pip install -e .",
+        "pip_packages": ["pytest"],
+        "test_cmd": TEST_PYTEST,
+    }
+}
+
+SPECS_OPENLIBRARY_PRO = {
+    "default": {
+        "python": "3.11",
+        "install": "python -m pip install -e .",
+        "pip_packages": ["pytest"],
+        "test_cmd": TEST_PYTEST,
+    }
+}
+
+SPECS_QUTEBROWSER_PRO = {
+    "default": {
+        "python": "3.11",
+        "install": "python -m pip install -e .",
+        "pip_packages": ["pytest"],
+        "test_cmd": TEST_PYTEST,
+    }
+}
+
 # Constants - Task Instance Instllation Environment
 MAP_REPO_VERSION_TO_SPECS_PY = {
     "astropy/astropy": SPECS_ASTROPY,
@@ -924,6 +951,9 @@ MAP_REPO_VERSION_TO_SPECS_PY = {
     "sqlfluff/sqlfluff": SPECS_SQLFLUFF,
     "swe-bench/humaneval": SPECS_HUMANEVAL,
     "sympy/sympy": SPECS_SYMPY,
+    "ansible/ansible": SPECS_ANSIBLE_PRO,
+    "internetarchive/openlibrary": SPECS_OPENLIBRARY_PRO,
+    "qutebrowser/qutebrowser": SPECS_QUTEBROWSER_PRO,
 }
 
 # Constants - Repository Specific Installation Instructions

--- a/swebench/harness/grading.py
+++ b/swebench/harness/grading.py
@@ -8,7 +8,6 @@ from swebench.harness.constants import (
     FAIL_TO_PASS,
     KEY_INSTANCE_ID,
     KEY_PREDICTION,
-    MAP_REPO_VERSION_TO_SPECS,
     PASS_TO_FAIL,
     PASS_TO_PASS,
     RESET_FAILED,
@@ -21,6 +20,7 @@ from swebench.harness.constants import (
 )
 from swebench.harness.test_spec.test_spec import TestSpec
 from swebench.harness.log_parsers import MAP_REPO_TO_PARSER
+from swebench.harness.test_spec.utils import resolve_repo_version_spec
 
 
 # MARK: Utility functions
@@ -51,7 +51,8 @@ def get_logs_eval(test_spec: TestSpec, log_fp: str) -> tuple[dict[str, str], boo
     repo = test_spec.repo
     version = test_spec.version
     log_parser = MAP_REPO_TO_PARSER[repo]
-    test_cmd = MAP_REPO_VERSION_TO_SPECS[repo][version]["test_cmd"]
+    _, specs = resolve_repo_version_spec(repo, version)
+    test_cmd = specs["test_cmd"]
     if isinstance(test_cmd, list):
         test_cmd = test_cmd[-1]
 

--- a/swebench/harness/log_parsers/go.py
+++ b/swebench/harness/log_parsers/go.py
@@ -38,4 +38,8 @@ MAP_REPO_TO_PARSER_GO = {
     "prometheus/prometheus": parse_log_gotest,
     "gohugoio/hugo": parse_log_gotest,
     "gin-gonic/gin": parse_log_gotest,
+    "flipt-io/flipt": parse_log_gotest,
+    "future-architect/vuls": parse_log_gotest,
+    "gravitational/teleport": parse_log_gotest,
+    "navidrome/navidrome": parse_log_gotest,
 }

--- a/swebench/harness/log_parsers/javascript.py
+++ b/swebench/harness/log_parsers/javascript.py
@@ -350,4 +350,8 @@ MAP_REPO_TO_PARSER_JS = {
     "mrdoob/three.js": parse_log_tap,
     "preactjs/preact": parse_log_karma,
     "axios/axios": parse_log_tap,
+    "NodeBB/NodeBB": parse_log_jest,
+    "element-hq/element-web": parse_log_jest,
+    "protonmail/webclients": parse_log_jest,
+    "tutao/tutanota": parse_log_jest,
 }

--- a/swebench/harness/log_parsers/python.py
+++ b/swebench/harness/log_parsers/python.py
@@ -286,4 +286,7 @@ MAP_REPO_TO_PARSER_PY = {
     "sqlfluff/sqlfluff": parse_log_sqlfluff,
     "sphinx-doc/sphinx": parse_log_sphinx,
     "sympy/sympy": parse_log_sympy,
+    "ansible/ansible": parse_log_pytest,
+    "internetarchive/openlibrary": parse_log_pytest,
+    "qutebrowser/qutebrowser": parse_log_pytest,
 }

--- a/swebench/harness/test_spec/javascript.py
+++ b/swebench/harness/test_spec/javascript.py
@@ -1,12 +1,16 @@
 import json
 import re
+import shlex
 
 from pathlib import Path
 from swebench.harness.constants import (
     END_TEST_OUTPUT,
     START_TEST_OUTPUT,
 )
-from swebench.harness.test_spec.utils import make_eval_script_list_common
+from swebench.harness.test_spec.utils import (
+    make_eval_script_list_common,
+    parse_instance_list_field,
+)
 from unidiff import PatchSet
 
 
@@ -62,8 +66,50 @@ def get_test_cmds_calypso(instance) -> list:
     return test_cmds
 
 
+def _extract_jest_targets(instance, max_targets: int = 12) -> list[str]:
+    selected = parse_instance_list_field(instance, "selected_test_files_to_run")
+    targets = []
+    for entry in selected:
+        # Some datasets include "path | test name"; extract path side only.
+        path_part = entry.split(" | ", 1)[0].strip()
+        if "/" in path_part and re.search(r"\.(js|jsx|ts|tsx)$", path_part):
+            targets.append(path_part)
+    deduped = []
+    seen = set()
+    for target in targets:
+        if target in seen:
+            continue
+        seen.add(target)
+        deduped.append(target)
+    return deduped[:max_targets]
+
+
+def _quote_targets(targets: list[str]) -> str:
+    return " ".join(shlex.quote(x) for x in targets)
+
+
+def get_test_cmds_nodebb(instance) -> list:
+    targets = _extract_jest_targets(instance)
+    quoted_targets = _quote_targets(targets)
+    if quoted_targets:
+        return [f"npx mocha --exit {quoted_targets}"]
+    return ["npx mocha --exit"]
+
+
+def get_test_cmds_jest_selected(instance) -> list:
+    targets = _extract_jest_targets(instance)
+    quoted_targets = _quote_targets(targets)
+    if quoted_targets:
+        return [f"npx jest --runInBand --verbose {quoted_targets}"]
+    return ["npx jest --runInBand --verbose"]
+
+
 MAP_REPO_TO_TEST_CMDS = {
     "Automattic/wp-calypso": get_test_cmds_calypso,
+    "NodeBB/NodeBB": get_test_cmds_nodebb,
+    "element-hq/element-web": get_test_cmds_jest_selected,
+    "protonmail/webclients": get_test_cmds_jest_selected,
+    "tutao/tutanota": get_test_cmds_jest_selected,
 }
 
 

--- a/swebench/harness/test_spec/python.py
+++ b/swebench/harness/test_spec/python.py
@@ -8,7 +8,6 @@ from swebench.harness.constants import (
     MAP_REPO_TO_ENV_YML_PATHS,
     MAP_REPO_TO_INSTALL,
     MAP_REPO_TO_REQS_PATHS,
-    MAP_REPO_VERSION_TO_SPECS,
     NON_TEST_EXTS,
     SWE_BENCH_URL_RAW,
     START_TEST_OUTPUT,
@@ -415,14 +414,13 @@ def make_eval_script_list_py(
     apply_test_patch_command = (
         f"git apply -v - <<'{HEREDOC_DELIMITER}'\n{test_patch}\n{HEREDOC_DELIMITER}"
     )
-    test_command = " ".join(
-        [
-            MAP_REPO_VERSION_TO_SPECS[instance["repo"]][instance["version"]][
-                "test_cmd"
-            ],
-            *get_test_directives(instance),
-        ]
-    )
+    test_cmd = specs["test_cmd"]
+    base_test_commands = [test_cmd] if isinstance(test_cmd, str) else test_cmd
+    test_directives = get_test_directives(instance)
+    if len(base_test_commands) == 1 and test_directives:
+        test_commands = [" ".join([base_test_commands[0], *test_directives])]
+    else:
+        test_commands = base_test_commands
     eval_commands = [
         "source /opt/miniconda3/bin/activate",
         f"conda activate {env_name}",
@@ -446,7 +444,7 @@ def make_eval_script_list_py(
         reset_tests_command,
         apply_test_patch_command,
         f": '{START_TEST_OUTPUT}'",
-        test_command,
+        *test_commands,
         f": '{END_TEST_OUTPUT}'",
         reset_tests_command,  # Revert tests after done, leave the repo in the same state as before
     ]

--- a/swebench/harness/test_spec/test_spec.py
+++ b/swebench/harness/test_spec/test_spec.py
@@ -1,15 +1,13 @@
 import hashlib
-import json
 
 from dataclasses import dataclass
-from typing import Any, Optional, Union, cast
+from typing import Optional, Union, cast
 
 from swebench.harness.constants import (
     DEFAULT_DOCKER_SPECS,
     KEY_INSTANCE_ID,
     LATEST,
     MAP_REPO_TO_EXT,
-    MAP_REPO_VERSION_TO_SPECS,
     SWEbenchInstance,
 )
 from swebench.harness.dockerfiles import (
@@ -21,6 +19,10 @@ from swebench.harness.test_spec.create_scripts import (
     make_repo_script_list,
     make_env_script_list,
     make_eval_script_list,
+)
+from swebench.harness.test_spec.utils import (
+    parse_instance_list_field,
+    resolve_instance_spec,
 )
 
 
@@ -192,21 +194,23 @@ def make_test_spec(
     hints_text = instance.get("hints_text")  # Unused
     test_patch = instance["test_patch"]
 
-    def _from_json_or_obj(key: str) -> Any:
-        """If key points to string, load with json"""
-        if key not in instance:
-            # If P2P, F2P keys not found, it's a validation instance
-            return []
-        if isinstance(instance[key], str):
-            return json.loads(instance[key])
-        return instance[key]
-
-    pass_to_pass = _from_json_or_obj("PASS_TO_PASS")
-    fail_to_pass = _from_json_or_obj("FAIL_TO_PASS")
+    pass_to_pass = parse_instance_list_field(
+        instance, "PASS_TO_PASS", alt_keys=("pass_to_pass",)
+    )
+    fail_to_pass = parse_instance_list_field(
+        instance, "FAIL_TO_PASS", alt_keys=("fail_to_pass",)
+    )
 
     env_name = "testbed"
     repo_directory = f"/{env_name}"
-    specs = MAP_REPO_VERSION_TO_SPECS[repo][version]
+    try:
+        resolved_version, specs = resolve_instance_spec(instance)
+    except KeyError as exc:
+        raise KeyError(
+            f"Unable to resolve harness specs for repo '{repo}' with version "
+            f"'{version}'. Add repo specs or a default version fallback."
+        ) from exc
+    version = "default" if resolved_version is None else str(resolved_version)
     docker_specs = specs.get("docker_specs", {})
 
     repo_script_list = make_repo_script_list(

--- a/swebench/harness/test_spec/utils.py
+++ b/swebench/harness/test_spec/utils.py
@@ -1,3 +1,10 @@
+import ast
+import json
+import os
+import re
+
+from typing import Any
+
 from swebench.harness.constants import (
     END_TEST_OUTPUT,
     MAP_REPO_VERSION_TO_SPECS,
@@ -9,10 +16,143 @@ from swebench.harness.utils import get_modified_files
 # MARK: Test Command Creation Functions
 
 
+DEFAULT_SPEC_VERSION_KEYS = ("default", None, "latest")
+
+
+def parse_instance_list_field(
+    instance: dict[str, Any], key: str, alt_keys: tuple[str, ...] = ()
+) -> list[str]:
+    """
+    Parse a list-like instance field that may be encoded as:
+    - a Python list
+    - a JSON list string
+    - a Python repr list string (single quotes)
+    """
+    value: Any = None
+    for candidate_key in (key, *alt_keys):
+        if candidate_key in instance:
+            value = instance[candidate_key]
+            break
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [str(x) for x in value]
+    if not isinstance(value, str):
+        return [str(value)]
+
+    value = value.strip()
+    if not value:
+        return []
+
+    for parser in (json.loads, ast.literal_eval):
+        try:
+            parsed = parser(value)
+            if isinstance(parsed, list):
+                return [str(x) for x in parsed]
+        except Exception:
+            pass
+
+    if value.startswith("[") and value.endswith("]"):
+        inner = value[1:-1]
+    else:
+        inner = value
+    return [x.strip().strip("'\"") for x in inner.split(",") if x.strip()]
+
+
+def resolve_repo_version_spec(repo: str, version: Any) -> tuple[Any, dict]:
+    """
+    Resolve repo/version specs with a fallback chain for versionless datasets
+    like SWE-bench Pro.
+    """
+    repo_specs = MAP_REPO_VERSION_TO_SPECS.get(repo)
+    if repo_specs is None:
+        raise KeyError(
+            f"Repo '{repo}' has no harness specs in MAP_REPO_VERSION_TO_SPECS"
+        )
+
+    candidates = []
+    if version is not None:
+        candidates.append(version)
+    candidates.extend(DEFAULT_SPEC_VERSION_KEYS)
+
+    for candidate in candidates:
+        if candidate in repo_specs:
+            return candidate, repo_specs[candidate]
+
+    if len(repo_specs) == 1:
+        resolved_version = next(iter(repo_specs.keys()))
+        return resolved_version, repo_specs[resolved_version]
+
+    available = ", ".join(sorted(str(x) for x in repo_specs.keys()))
+    raise KeyError(
+        f"Unable to resolve specs for repo '{repo}' version '{version}'. "
+        f"Available keys: {available}"
+    )
+
+
+def resolve_instance_spec(instance: dict[str, Any]) -> tuple[Any, dict]:
+    return resolve_repo_version_spec(instance["repo"], instance.get("version"))
+
+
+def _dedupe_keep_order(items: list[str]) -> list[str]:
+    seen = set()
+    deduped = []
+    for item in items:
+        if item in seen:
+            continue
+        seen.add(item)
+        deduped.append(item)
+    return deduped
+
+
+def _get_test_cmds_go_selected(instance: dict[str, Any], _base_test_cmd: Any) -> list[str]:
+    selected = parse_instance_list_field(instance, "selected_test_files_to_run")
+    test_names = []
+    packages = []
+
+    for entry in selected:
+        stripped = entry.strip()
+        if not stripped:
+            continue
+        if stripped.endswith(".go"):
+            pkg_dir = os.path.dirname(stripped)
+            packages.append("." if not pkg_dir else f"./{pkg_dir}")
+        name_candidate = stripped.split("//", 1)[0].split("/", 1)[0].split("#", 1)[0]
+        if re.match(r"^Test", name_candidate):
+            test_names.append(name_candidate)
+
+    if not packages:
+        for modified in get_modified_files(instance.get("test_patch", "")):
+            if modified.endswith("_test.go"):
+                pkg_dir = os.path.dirname(modified)
+                packages.append("." if not pkg_dir else f"./{pkg_dir}")
+
+    packages = _dedupe_keep_order(packages)
+    if not packages:
+        packages = ["./..."]
+    package_expr = " ".join(packages[:6])
+
+    test_names = _dedupe_keep_order(test_names)
+    if test_names:
+        max_names = 32
+        regex = "^(" + "|".join(re.escape(name) for name in test_names[:max_names]) + ")$"
+        return [f"go test -v {package_expr} -run '{regex}'"]
+    return [f"go test -v {package_expr}"]
+
+
+MAP_REPO_TO_TEST_CMDS = {
+    "flipt-io/flipt": _get_test_cmds_go_selected,
+    "future-architect/vuls": _get_test_cmds_go_selected,
+    "gravitational/teleport": _get_test_cmds_go_selected,
+    "navidrome/navidrome": _get_test_cmds_go_selected,
+}
+
+
 def get_test_cmds(instance) -> list:
-    test_cmd = MAP_REPO_VERSION_TO_SPECS[instance["repo"]][instance["version"]][
-        "test_cmd"
-    ]
+    _, specs = resolve_instance_spec(instance)
+    test_cmd = specs["test_cmd"]
+    if instance["repo"] in MAP_REPO_TO_TEST_CMDS:
+        return MAP_REPO_TO_TEST_CMDS[instance["repo"]](instance, test_cmd)
     return [test_cmd] if isinstance(test_cmd, str) else test_cmd
 
 

--- a/tests/test_swebench_pro_support.py
+++ b/tests/test_swebench_pro_support.py
@@ -1,0 +1,57 @@
+from swebench.harness.test_spec.test_spec import make_test_spec
+from swebench.harness.test_spec.utils import (
+    parse_instance_list_field,
+    resolve_repo_version_spec,
+)
+
+
+PRO_REPOS = [
+    "NodeBB/NodeBB",
+    "ansible/ansible",
+    "element-hq/element-web",
+    "flipt-io/flipt",
+    "future-architect/vuls",
+    "gravitational/teleport",
+    "internetarchive/openlibrary",
+    "navidrome/navidrome",
+    "protonmail/webclients",
+    "qutebrowser/qutebrowser",
+    "tutao/tutanota",
+]
+
+
+def _instance_for_repo(repo: str) -> dict:
+    return {
+        "instance_id": f"instance_{repo.replace('/', '__')}-dummy",
+        "repo": repo,
+        "base_commit": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+        "patch": "",
+        "test_patch": "",
+        "problem_statement": "Dummy",
+        "fail_to_pass": "['TestOne', 'TestTwo']",
+        "pass_to_pass": "[]",
+        "selected_test_files_to_run": '["tests/unit/test_dummy.py"]',
+    }
+
+
+def test_parse_instance_list_field_accepts_python_repr_list() -> None:
+    parsed = parse_instance_list_field(
+        {"fail_to_pass": "['a', 'b', 'c']"},
+        "FAIL_TO_PASS",
+        alt_keys=("fail_to_pass",),
+    )
+    assert parsed == ["a", "b", "c"]
+
+
+def test_resolve_repo_version_spec_supports_versionless_default() -> None:
+    resolved_version, specs = resolve_repo_version_spec("flipt-io/flipt", None)
+    assert resolved_version == "default"
+    assert "test_cmd" in specs
+
+
+def test_make_test_spec_supports_all_swebench_pro_repos() -> None:
+    for repo in PRO_REPOS:
+        spec = make_test_spec(_instance_for_repo(repo), namespace="none")
+        assert spec.repo == repo
+        assert spec.version == "default"
+        assert spec.eval_script_list


### PR DESCRIPTION
## Summary
- add robust repo/version spec resolution fallback for versionless rows (for example SWE-bench Pro)
- add default harness specs for 11 SWE-bench Pro repos across Python/Go/JS maps
- add parser mappings for those repos and targeted test command builders for Go/JS selected-test metadata
- parse lowercase `fail_to_pass` / `pass_to_pass` fields and Python-repr list strings used by Pro rows
- include Rust fixture files in package data so git installs import cleanly
- add focused Pro support tests in `tests/test_swebench_pro_support.py`

## Validation
- `uv run --with pytest pytest tests/test_swebench_pro_support.py -q`
- `uv run python - <<'PY'\nfrom datasets import load_dataset\nfrom swebench.harness.test_spec.test_spec import make_test_spec\nrows = load_dataset('ScaleAI/SWE-bench_Pro', split='test')\nfor row in rows:\n    make_test_spec(row, namespace='none')\nprint('ok', len(rows))\nPY`
