### PR TITLE
Fix broken link to collection tutorial in README

### DIFF
--- a/swebench/collect/README.md
+++ b/swebench/collect/README.md
@@ -11,7 +11,7 @@
 
 This folder includes the code for the first two parts of the benchmark construction procedure as described in the paper, specifically 1. Repo selection and data scraping, and 2. Attribute-based filtering.
 
-We include a comprehensive [tutorial](docs/guides/collection.md) that describes the end-to-end procedure for collecting evaluation task instances from PyPI repositories.
+We include a comprehensive [tutorial](../../docs/assets/collection.md) that describes the end-to-end procedure for collecting evaluation task instances from PyPI repositories.
 
 > SWE-bench's collection pipeline is currently designed to target PyPI packages. We hope to expand SWE-bench to more repositories and languages in the future.
 


### PR DESCRIPTION
## Summary
- Fixed broken link in `swebench/collect/README.md` (line 14) that pointed to the non-existent `docs/guides/collection.md`
- Updated the link to point to the correct location at `docs/assets/collection.md`

Fixes #469

## Test plan
- [ ] Verify the link in `swebench/collect/README.md` renders correctly on GitHub and navigates to the collection tutorial

🤖 Generated with [Claude Code](https://claude.com/claude-code)