### PR TITLE
Add missing -e flag to eval_script bash options

### DIFF
--- a/swebench/harness/test_spec/test_spec.py
+++ b/swebench/harness/test_spec/test_spec.py
@@ -56,7 +56,7 @@ class TestSpec:
     @property
     def eval_script(self):
         return (
-            "\n".join(["#!/bin/bash", "set -uxo pipefail"] + self.eval_script_list)
+            "\n".join(["#!/bin/bash", "set -euxo pipefail"] + self.eval_script_list)
             + "\n"
         )
         # Don't exit early because we need to revert tests at the end


### PR DESCRIPTION
## Summary
- Added the missing `-e` flag to the `eval_script` property in the `TestSpec` dataclass
- The `eval_script` was using `set -uxo pipefail` while `setup_env_script` and `install_repo_script` correctly used `set -euxo pipefail`
- The `-e` flag ensures the script exits immediately on error, so test failures are properly caught

Fixes #526

## Test plan
- [ ] Verify the eval script now includes `set -euxo pipefail`
- [ ] Run existing tests to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)