### PR TITLE
Fix inverted condition omitting container/image data from report

### DIFF
--- a/swebench/harness/reporting.py
+++ b/swebench/harness/reporting.py
@@ -141,7 +141,7 @@ def make_run_report(
         "error_ids": list(sorted(error_ids)),
         "schema_version": 2,
     }
-    if not client:
+    if client:
         report.update(
             {
                 "unstopped_instances": len(unstopped_containers),


### PR DESCRIPTION
## Summary
- **Bug:** In `make_run_report()` (`swebench/harness/reporting.py`), the `unstopped_containers` and `unremoved_images` sets are populated only when a Docker `client` is provided (line 89: `if client:`), and printed only when `client` is provided (line 122: `if client:`). However, the condition for writing these fields to the JSON report was inverted: `if not client:` (line 144).
- **Effect:** When a Docker client is provided, the collected container/image data is printed to stdout but **never written to the JSON report file**. When no client is provided, empty sets are written to the report — adding no information.
- **Fix:** Change `if not client:` to `if client:` on line 144 so the report includes the data when it's actually been collected.

## Test plan
- [x] Single-word change (`not` removed), matching the two existing `if client:` guards at lines 89 and 122
- [x] Verified the three conditions now consistently gate on `client` being present

🤖 Generated with [Claude Code](https://claude.com/claude-code)