### PR TITLE
Fix off-by-one in get_last_idx including extra trailing context line

### DIFF
--- a/swebench/harness/utils.py
+++ b/swebench/harness/utils.py
@@ -205,7 +205,7 @@ def get_last_idx(charlist):
     """Get index of last occurrence of "-" or "+" in charlist"""
     char_idx = get_first_idx(charlist[::-1])
     last_idx = len(charlist) - char_idx
-    return last_idx + 1
+    return last_idx
 
 
 def strip_content(hunk):

--- a/swebench/inference/make_datasets/utils.py
+++ b/swebench/inference/make_datasets/utils.py
@@ -30,7 +30,7 @@ def get_first_idx(charlist):
 def get_last_idx(charlist):
     char_idx = get_first_idx(charlist[::-1])
     last_idx = len(charlist) - char_idx
-    return last_idx + 1
+    return last_idx
 
 
 def strip_content(hunk):


### PR DESCRIPTION
## Summary

`get_last_idx` computes the exclusive-end index for slicing a diff hunk down to the range from the first `+`/`-` line to the last. The arithmetic `len(charlist) - char_idx` already yields the correct exclusive-end index (one past the last `+`/`-` position), but the function adds a spurious `+ 1`.

**Trace with concrete input:**
```
charlist = [' ', '-', '+', ' ', None]   # last +/- at index 2
reversed  = [None, ' ', '+', '-', ' ']
char_idx  = 2     # get_first_idx finds '+' at rev index 2
last_idx  = 5 - 2 = 3  # correct exclusive end: charlist[1:3] = ['-', '+']
return 3 + 1 = 4       # BUG: charlist[1:4] = ['-', '+', ' '] — extra context line
```

**Impact:** `strip_content` includes one extra trailing context line per hunk. `get_hunk_stats` then miscounts it, inflating `pre_len`/`post_len` in the reconstructed `@@ -start,N +start,N @@` header, producing a malformed patch.

**Fix:** Remove the `+ 1` in both identical copies (`swebench/harness/utils.py` and `swebench/inference/make_datasets/utils.py`).

## Test plan

- [ ] Verify `get_last_idx([' ', '-', '+', ' '])` returns `3` (not `4`)
- [ ] Verify `extract_minimal_patch` output has correct hunk headers matching actual line counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)