### PR TITLE
Fix get_readme_files() checking CWD instead of repo path

### DIFF
--- a/swebench/inference/make_datasets/bm25_retrieval.py
+++ b/swebench/inference/make_datasets/bm25_retrieval.py
@@ -63,7 +63,7 @@ class ContextManager:
 
     def get_readme_files(self):
         files = os.listdir(self.repo_path)
-        files = list(filter(lambda x: os.path.isfile(x), files))
+        files = list(filter(lambda x: os.path.isfile(os.path.join(self.repo_path, x)), files))
         files = list(filter(lambda x: x.lower().startswith("readme"), files))
         return files
 

--- a/swebench/inference/make_datasets/utils.py
+++ b/swebench/inference/make_datasets/utils.py
@@ -172,7 +172,7 @@ class ContextManager:
 
     def get_readme_files(self):
         files = os.listdir(self.repo_path)
-        files = list(filter(lambda x: os.path.isfile(x), files))
+        files = list(filter(lambda x: os.path.isfile(os.path.join(self.repo_path, x)), files))
         files = list(filter(lambda x: x.lower().startswith("readme"), files))
         return files
 


### PR DESCRIPTION
## Bug

In both `ContextManager.get_readme_files()` implementations (`bm25_retrieval.py` and `utils.py`):

```python
files = os.listdir(self.repo_path)          # returns bare filenames
files = list(filter(lambda x: os.path.isfile(x), files))  # checks CWD, not repo_path
```

`os.listdir()` returns bare filenames (e.g., `"README.md"`), but `os.path.isfile()` resolves them against the current working directory, not `self.repo_path`. When CWD != repo path, all files are filtered out and the function silently returns an empty list — losing README context for BM25 retrieval and dataset creation.

Compare with `run_live.py:get_readme_files()` which correctly uses `Path(repo_path).iterdir()` and `x.is_file()` (full paths).

## Fix

Join filenames with `self.repo_path` before the `os.path.isfile()` check. Fixed in both `bm25_retrieval.py` and `utils.py`.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>