### PR TITLE
Fix make_code_text_edits_only dropping hunks near the top of a file

### DIFF
--- a/swebench/inference/make_datasets/create_instance.py
+++ b/swebench/inference/make_datasets/create_instance.py
@@ -143,7 +143,10 @@ def make_code_text_edits_only(files_dict, patch, add_line_numbers=True):
         source_file = patched_file.source_file.split("a/", 1)[-1]
         files[source_file] = list()
         for hunk in patched_file:
-            start = hunk.source_start - 15
+            # Clamp to 0 so hunks near the top of the file still get
+            # a non-empty slice (Python's negative indexing would
+            # otherwise turn [-n:end] into an empty window for large files).
+            start = max(0, hunk.source_start - 15)
             end = start + hunk.source_length + 15
             files[source_file].append((start, end))
     all_text = ""


### PR DESCRIPTION
## Bug

`make_code_text_edits_only` in `swebench/inference/make_datasets/create_instance.py` (used by the `style-2-edits-only` prompt function) silently emits an empty window for any hunk whose `source_start` is <= 15, dropping that hunk's context entirely from the prompt.

## Root cause

\`\`\`python
for hunk in patched_file:
    start = hunk.source_start - 15
    end = start + hunk.source_length + 15
    files[source_file].append((start, end))
...
all_text += \"\\n\".join(content_with_lines[start:end])
\`\`\`

`start` can become negative (e.g. `hunk.source_start == 5` → `start = -10`). Python's list slicing interprets a negative start as `len(seq) + start`, so for any file longer than ~15 lines the slice collapses to an empty range:

\`\`\`python
>>> content_with_lines = [f\"line {i}\" for i in range(1, 101)]  # 100 lines
>>> content_with_lines[-10:8]
[]
\`\`\`

Because `end` (8 in this example) is smaller than the resolved positive start (90), the intersection is empty. The hunk's context silently disappears from the generated `[start of file] ... [end of file]` block, which is the code snippet the LLM is asked to edit.

Reproduction: any SWE-bench instance whose gold patch has a hunk starting at line <= 15 in a source file longer than ~15 lines, generated via `--prompt_style style-2-edits-only`. The resulting `file_contents` will have no context for that hunk.

## Fix

Clamp `start` to 0 so near-top hunks get the intended \"15 lines before + hunk + ~15 after\" window, truncated at the start of the file:

\`\`\`diff
         for hunk in patched_file:
-            start = hunk.source_start - 15
+            # Clamp to 0 so hunks near the top of the file still get
+            # a non-empty slice (Python's negative indexing would
+            # otherwise turn [-n:end] into an empty window for large files).
+            start = max(0, hunk.source_start - 15)
             end = start + hunk.source_length + 15
\`\`\`

The existing `if start > 0: all_text += \"...\\n\"` guard around the slice already handles the \"no prior context to elide\" case — with `start == 0` it correctly omits the leading `\"...\"`.

No behavioral change for hunks with `source_start > 15` (the previous `start` was already positive for those). Fix only affects hunks near the top of files, where it restores the non-empty window the function was clearly intended to produce.