### PR TITLE
Fix make_code_text_edits_only providing 0 trailing context lines

### DIFF
--- a/swebench/inference/make_datasets/create_instance.py
+++ b/swebench/inference/make_datasets/create_instance.py
@@ -144,7 +144,7 @@ def make_code_text_edits_only(files_dict, patch, add_line_numbers=True):
         files[source_file] = list()
         for hunk in patched_file:
             start = hunk.source_start - 15
-            end = start + hunk.source_length + 15
+            end = hunk.source_start - 1 + hunk.source_length + 15
             files[source_file].append((start, end))
     all_text = ""
     for filename, content in files_dict.items():


### PR DESCRIPTION
## Summary

`make_code_text_edits_only` is supposed to build a context window of 15 lines before each hunk, the hunk itself, and 15 lines after. The trailing context is broken:

```python
start = hunk.source_start - 15
end = start + hunk.source_length + 15
```

Expanding: `end = (source_start - 15) + source_length + 15 = source_start + source_length`. The `+15` trailing context just cancels the `-15` from `start`, so `end` lands exactly at the hunk's last line — **0 trailing context** for every hunk.

| `source_start` | `source_length` | Current `end` | Trailing ctx |
|---|---|---|---|
| 100 | 5 | 105 | **0 lines** |
| 50 | 3 | 53 | **0 lines** |

**Fix:** Anchor `end` to the 0-based hunk position (`source_start - 1`) rather than to the already-offset `start`:

```python
end = hunk.source_start - 1 + hunk.source_length + 15
```

This correctly provides 15 lines of trailing context after each hunk.

## Test plan

- [x] Verified arithmetic: for source_start=100, length=5, new end=119 (15 trailing lines)
- [ ] Existing tests should continue to pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)