### PR TITLE
Fix django hints returning tuples instead of joined string

### DIFF
--- a/swebench/collect/utils.py
+++ b/swebench/collect/utils.py
@@ -402,6 +402,6 @@ def extract_problem_statement_and_hints_django(
 
             # Append the comment and timestamp as a tuple to the comments list
             if timestamp < commit_time:
-                all_hints_text.append((comment_text, timestamp))
+                all_hints_text.append(comment_text)
 
-    return text, all_hints_text
+    return text, "\n".join(all_hints_text) if all_hints_text else ""


### PR DESCRIPTION
## Bug

`extract_problem_statement_and_hints_django` appends `(comment_text, timestamp)` tuples to `all_hints_text` and returns the raw list. The caller `extract_problem_statement_and_hints` declares return type `tuple[str, str]`, and the non-django code path correctly joins hint strings with `"\n".join()`.

For django repos, the `hints_text` field ends up as a list of `[text, timestamp_float]` arrays instead of a string, causing:
1. Type inconsistency with the declared return type
2. Timestamps leaking into hint text
3. Different data format for django vs. all other repos

## Fix

- Changed `append((comment_text, timestamp))` to `append(comment_text)` — timestamp is only needed for the `< commit_time` filter, not in the output
- Changed `return text, all_hints_text` to `return text, "\n".join(all_hints_text) if all_hints_text else ""` — matching the non-django path

🤖 Generated with [Claude Code](https://claude.ai/code)