### PR TITLE
Honor --report_dir CLI arg when writing final run report

### DIFF
--- a/swebench/harness/reporting.py
+++ b/swebench/harness/reporting.py
@@ -22,6 +22,7 @@ def make_run_report(
     namespace: str = None,
     instance_image_tag: str = "latest",
     env_image_tag: str = "latest",
+    report_dir: Path | str = ".",
 ) -> Path:
     """
     Make a final evaluation and run report of the instances that have been run.
@@ -149,7 +150,7 @@ def make_run_report(
                 "unremoved_images": list(sorted(unremoved_images)),
             }
         )
-    report_file = Path(
+    report_file = Path(report_dir) / (
         list(predictions.values())[0][KEY_MODEL].replace("/", "__")
         + f".{run_id}"
         + ".json"

--- a/swebench/harness/run_evaluation.py
+++ b/swebench/harness/run_evaluation.py
@@ -574,6 +574,7 @@ def main(
         namespace,
         instance_image_tag,
         env_image_tag,
+        report_dir,
     )
 
 


### PR DESCRIPTION
## Bug
Fixes #449.

`python -m swebench.harness.run_evaluation --report_dir reports ...` creates the `reports/` directory, but the final report JSON is still written to the current working directory, ignoring the flag.

## Root cause
`run_evaluation.py` accepts `--report_dir` and mkdirs it, but then calls `make_run_report(...)` without passing `report_dir` through. `make_run_report` in `swebench/harness/reporting.py` constructs `report_file = Path(<model>.<run_id>.json)` — a bare filename, always relative to `os.getcwd()`.

## Fix
- Add `report_dir: Path | str = "."` to `make_run_report`'s signature and join it into the final `report_file` path.
- Forward `report_dir` from `run_evaluation.main()` to `make_run_report`.

Default `"."` preserves the existing behavior for every other caller (e.g., `run_evaluation_modal.py`), so nothing else needs to change.