### PR TITLE
Fix off-by-one / stale-entry bugs in log_all_pulls limits

### DIFF
--- a/swebench/collect/print_pulls.py
+++ b/swebench/collect/print_pulls.py
@@ -41,12 +41,12 @@ def log_all_pulls(
 
     with open(output, "w") as file:
         for i_pull, pull in enumerate(repo.get_all_pulls()):
-            setattr(pull, "resolved_issues", repo.extract_resolved_issues(pull))
-            print(json.dumps(obj2dict(pull)), end="\n", flush=True, file=file)
             if max_pulls is not None and i_pull >= max_pulls:
                 break
             if cutoff_date is not None and pull.created_at < cutoff_date:
                 break
+            setattr(pull, "resolved_issues", repo.extract_resolved_issues(pull))
+            print(json.dumps(obj2dict(pull)), end="\n", flush=True, file=file)
 
 
 def log_single_pull(


### PR DESCRIPTION
## Bug

In \`swebench/collect/print_pulls.py\`, \`log_all_pulls\` performed the \`max_pulls\` and \`cutoff_date\` checks **after** writing the current PR to disk. Two observable consequences:

1. **\`max_pulls=N\` writes N+1 PRs.** With \`max_pulls=1\` the loop writes the PR at \`i_pull=0\`, then evaluates \`0 >= 1\` (False); writes the PR at \`i_pull=1\`, then evaluates \`1 >= 1\` (True) and breaks. Output file ends up with two PRs instead of one.
2. **\`cutoff_date\` logs one stale PR before stopping.** \`get_all_pulls\` yields PRs in descending \`created\` order, so the first PR that trips the cutoff check (and every one after) is older than the cutoff and should not appear in the output — but the current code writes it before breaking.

## Root cause

The two \`break\` guards sit after \`setattr(pull, \"resolved_issues\", ...)\` + \`print(json.dumps(obj2dict(pull)), ...)\`, so the current pull is always serialized before the loop decides whether to stop.

## Fix

Move both guards above the \`setattr\` / \`print\` block. This makes \`max_pulls=N\` produce exactly N entries and ensures no PR older than \`cutoff_date\` is written. As a side benefit, the skipped PRs also no longer trigger an \`extract_resolved_issues\` call (which hits the GitHub API).