### PR TITLE
Fix make_run_report writing docker fields only when client is absent

### DIFF
--- a/swebench/harness/reporting.py
+++ b/swebench/harness/reporting.py
@@ -141,7 +141,7 @@ def make_run_report(
         "error_ids": list(sorted(error_ids)),
         "schema_version": 2,
     }
-    if not client:
+    if client:
         report.update(
             {
                 "unstopped_instances": len(unstopped_containers),


### PR DESCRIPTION
## Bug

In \`swebench/harness/reporting.py\`, \`make_run_report\` collects stray docker containers/images under \`if client:\` (lines 89-110), prints them under \`if client:\` (lines 122-124), but then attaches them to the JSON report under the inverse guard:

\`\`\`python
if not client:
    report.update(
        {
            \"unstopped_instances\": len(unstopped_containers),
            \"unstopped_containers\": list(sorted(unstopped_containers)),
            \"unremoved_images\": list(sorted(unremoved_images)),
        }
    )
\`\`\`

## Root cause

\`unstopped_containers\` and \`unremoved_images\` are only populated when \`client\` is provided. With \`if not client:\`, the report includes these fields only in the branch where both sets are guaranteed to be empty, and omits them in the branch where they actually hold data.

## Fix

Flip the guard to \`if client:\` so the report contains the stray-container/image information exactly when it was collected and just printed.