### PR TITLE
Fix make_test_spec hardcoded x86_64 default that breaks ARM hosts

### DIFF
--- a/swebench/harness/test_spec/test_spec.py
+++ b/swebench/harness/test_spec/test_spec.py
@@ -1,5 +1,6 @@
 import hashlib
 import json
+import platform
 
 from dataclasses import dataclass
 from typing import Any, Optional, Union, cast
@@ -177,10 +178,12 @@ def make_test_spec(
     base_image_tag: str = LATEST,
     env_image_tag: str = LATEST,
     instance_image_tag: str = LATEST,
-    arch: str = "x86_64",
+    arch: Optional[str] = None,
 ) -> TestSpec:
     if isinstance(instance, TestSpec):
         return instance
+    if arch is None:
+        arch = "arm64" if platform.machine().lower() in ("arm64", "aarch64") else "x86_64"
     assert base_image_tag is not None, "base_image_tag cannot be None"
     assert env_image_tag is not None, "env_image_tag cannot be None"
     assert instance_image_tag is not None, "instance_image_tag cannot be None"


### PR DESCRIPTION
## Bug

`make_test_spec` in `swebench/harness/test_spec/test_spec.py` hardcodes `arch="x86_64"` as its default. On ARM64 hosts (Apple Silicon, AWS Graviton) this silently builds images for the wrong architecture unless the caller passes `arch="arm64"` explicitly.

Fixes #523.

## Root cause

```python
def make_test_spec(
    ...,
    arch: str = "x86_64",
) -> TestSpec:
```

None of the in-tree callers (`run_evaluation`, `docker_build`, `prepare_images`, `reporting`, `get_test_specs_from_dataset`) pass `arch`, so every ARM user inherits the broken default. The downstream `platform` property then returns `linux/x86_64` and image tags include `x86_64`, producing wrong-arch builds.

## Fix

Change the default to `None` and detect the host arch via `platform.machine()` when unspecified:

- `arm64`/`aarch64` → `"arm64"`
- anything else → `"x86_64"`

Explicit callers that pass `arch` are unaffected. On x86_64 hosts, the resolved value is still `"x86_64"`, so there is no behavior change for existing x86 users — only ARM users, who are already broken today, are fixed.

## Why the fix is correct

- 1 new import (`platform`) + 3 lines of logic, all localized in `make_test_spec`.
- `platform.machine()` returns the host ISA (`arm64` on macOS Apple Silicon, `aarch64` on Linux ARM, `x86_64`/`AMD64` on Intel/AMD); lowering and matching the ARM aliases covers both macOS and Linux ARM hosts without affecting Windows `AMD64` or Linux `x86_64`.
- The `TestSpec.platform` property already only accepts `"x86_64"` and `"arm64"`, so the two-case detection matches the existing valid set exactly — no new values reach it.
- Callers that intentionally want `x86_64` on an ARM host can still do so by passing `arch="x86_64"` explicitly (the signature stays compatible with positional/keyword calls).