### PR TITLE
Read version file using the resolved absolute path in get_version

### DIFF
--- a/swebench/versioning/get_versions.py
+++ b/swebench/versioning/get_versions.py
@@ -82,7 +82,7 @@ def get_version(instance, is_build=False, path_repo=None):
             version_path_abs = os.path.join(path_repo, path_to_version)
             if os.path.exists(version_path_abs):
                 logger.info(f"Found version file at {path_to_version}")
-                with open(path_to_version) as f:
+                with open(version_path_abs) as f:
                     init_text = f.read()
         else:
             url = os.path.join(


### PR DESCRIPTION
## Bug

`get_version` in `swebench/versioning/get_versions.py` validates the candidate version file using the resolved absolute path, but then reads it using the raw relative path:

```python
version_path_abs = os.path.join(path_repo, path_to_version)
if os.path.exists(version_path_abs):
    logger.info(f"Found version file at {path_to_version}")
    with open(path_to_version) as f:   # <-- opens a CWD-relative path
        init_text = f.read()
```

## Root cause

The in-tree caller (`get_versions_from_build`) happens to `os.chdir(path_repo)` before calling `get_version(..., is_build=True, path_repo=path_repo)`, so the CWD-relative `open(path_to_version)` coincidentally resolves to the same file as `version_path_abs`. The existence check passes and the read succeeds only because of that chdir — not because the code is correct.

Any other caller that invokes `get_version(instance, is_build=True, path_repo=some_dir)` from a different working directory will:

1. See `os.path.exists(version_path_abs)` correctly find the file under `some_dir`.
2. Then `open(path_to_version)` will open a completely unrelated file under the caller's CWD (or raise `FileNotFoundError` if none exists with that name), feeding the wrong text into `_find_version_in_text`.

## Fix

Open `version_path_abs` — the path that was just validated — instead of `path_to_version`. The change is one line.

## Why the fix is correct

- `version_path_abs = os.path.join(path_repo, path_to_version)` is already the intended location of the file.
- Using it for both the `exists` check and the `open` makes the read path-correct regardless of the caller's CWD.
- For the existing `get_versions_from_build` call path, CWD is `path_repo`, so `path_to_version` and `version_path_abs` resolve to the same file today. Switching to `version_path_abs` is therefore behavior-preserving for the existing flow and only changes behavior in the previously-broken cases (different CWD / other callers).