### PR TITLE
Fix get_problem_statement dropping all comment bodies when include_comments=True

### DIFF
--- a/swebench/inference/run_live.py
+++ b/swebench/inference/run_live.py
@@ -51,7 +51,7 @@ def get_problem_statement(owner, repo, issue_num, ghapi, include_comments=False)
     if include_comments:
         all_comments = list(ghapi.issues.list_comments(owner, repo, issue_num))
         comments = [comment.body for comment in all_comments]
-        comment_text = "Comment: " if comments else "" + "\nComment:".join(comments)
+        comment_text = ("Comment: " if comments else "") + "\nComment:".join(comments)
         issue_text += "\n" + comment_text
     return issue_text
 


### PR DESCRIPTION
## Bug

In \`swebench/inference/run_live.py\`, \`get_problem_statement(..., include_comments=True)\` is supposed to append every issue comment to the problem statement. Instead, when \`comments\` is non-empty the function emits just the literal string \`\"Comment: \"\` and drops every comment body:

\`\`\`python
comment_text = \"Comment: \" if comments else \"\" + \"\nComment:\".join(comments)
issue_text += \"\n\" + comment_text
\`\`\`

## Root cause

The conditional expression has lower precedence than \`+\`, so Python parses the line as:

\`\`\`python
comment_text = \"Comment: \" if comments else (\"\" + \"\nComment:\".join(comments))
\`\`\`

- \`comments\` truthy → \`comment_text = \"Comment: \"\` and the actual comment text is never concatenated.
- \`comments\` falsy → \`comment_text = \"\" + \"\nComment:\".join([]) = \"\"\`, which is fine but unreachable in practice because this block is already gated by \`if comments:\` upstream once we reach real usage.

The author clearly intended to prepend \`\"Comment: \"\` *and then* append the joined comment bodies; the missing parentheses around the ternary collapse that to a bare prefix.

## Why the fix is correct

Wrapping the ternary in parentheses restores the intended evaluation:

\`\`\`python
comment_text = (\"Comment: \" if comments else \"\") + \"\nComment:\".join(comments)
\`\`\`

Now:
- \`comments = [\"a\", \"b\"]\` → \`\"Comment: a\nComment:b\"\` (prefix + joined bodies, matching the \`\"\nComment:\"\` delimiter pattern that only makes sense when a leading \`\"Comment: \"\` is present).
- \`comments = []\` → \`\"\" + \"\" = \"\"\`, unchanged from the original falsy branch.

This preserves behavior when \`include_comments=False\` (the guarded block is skipped entirely) and restores the documented behavior when comments are requested.