### PR TITLE
Fix get_versions_astropy/pvlib appending leaked loop variable t instead of task

### DIFF
--- a/swebench/versioning/extract_web/get_versions_astropy.py
+++ b/swebench/versioning/extract_web/get_versions_astropy.py
@@ -63,7 +63,7 @@ map_v_to_t = {}
 for task in data_tasks:
     if task["version"] not in map_v_to_t:
         map_v_to_t[task["version"]] = []
-    map_v_to_t[task["version"]].append(t)
+    map_v_to_t[task["version"]].append(task)
 
 # Save matplotlib versioned data to repository
 with open(

--- a/swebench/versioning/extract_web/get_versions_pvlib-python.py
+++ b/swebench/versioning/extract_web/get_versions_pvlib-python.py
@@ -64,7 +64,7 @@ map_v_to_t = {}
 for task in data_tasks:
     if task["version"] not in map_v_to_t:
         map_v_to_t[task["version"]] = []
-    map_v_to_t[task["version"]].append(t)
+    map_v_to_t[task["version"]].append(task)
 
 # Save matplotlib versioned data to repository
 with open(PATH_TASKS_PVLIB_V, "w") as f:


### PR DESCRIPTION
## Bug

`get_versions_astropy.py` and `get_versions_pvlib-python.py` build the version → task-list map with the wrong loop variable:

```python
# get_versions_astropy.py:66 (and pvlib-python.py:67)
map_v_to_t = {}
for task in data_tasks:
    if task["version"] not in map_v_to_t:
        map_v_to_t[task["version"]] = []
    map_v_to_t[task["version"]].append(t)   # <-- appends `t`, not `task`
```

## Root cause

`t` is a leaked loop variable from the preceding *"Assign version to each task instance"* block, which iterates `for t in version_to_time`. After that block completes, `t` holds the last `(version, date)` tuple from `version_to_time`. The later outer loop was renamed to iterate `task in data_tasks`, but the `.append(t)` call was not updated to match.

Every entry in `map_v_to_t` therefore ends up being the same 2-tuple rather than the task dict it should contain.

The sibling file `get_versions_matplotlib.py:50` shows the correct pattern — there the outer loop variable happens to be named `t`, so `.append(t)` is right. In astropy / pvlib the outer loop was renamed to `task` without updating the append.

## Why the fix is correct

Renaming to `map_v_to_t[task["version"]].append(task)` makes the append match the loop variable and the intent of the surrounding code — and matches what `get_versions_matplotlib.py` does (appending the iterated element into its own version bucket).

## Change

Two one-character edits (`t` → `task`), one per file. No other changes.