### PR TITLE
Route log_error in remove_image/cleanup_container to logger.error, not logger.info

### DIFF
--- a/swebench/harness/docker_utils.py
+++ b/swebench/harness/docker_utils.py
@@ -82,7 +82,7 @@ def remove_image(client, image_id, logger=None):
         raise_error = True
     else:
         # if logger is a logger object, use it
-        log_error = logger.info
+        log_error = logger.error
         log_info = logger.info
         raise_error = False
     try:
@@ -124,7 +124,7 @@ def cleanup_container(client, container, logger):
         raise_error = True
     else:
         # if logger is a logger object, use it
-        log_error = logger.info
+        log_error = logger.error
         log_info = logger.info
         raise_error = False
 


### PR DESCRIPTION
## Bug

`swebench/harness/docker_utils.py` exposes `remove_image` and `cleanup_container`, which both dispatch their logging callbacks based on the `logger` argument:

```python
if not logger:
    # if logger is None, print to stdout
    log_info = print
    log_error = print
    raise_error = True
elif logger == "quiet":
    # if logger is "quiet", don't print anything
    log_info = lambda x: None
    log_error = lambda x: None
    raise_error = True
else:
    # if logger is a logger object, use it
    log_error = logger.info          # ← routed to INFO
    log_info = logger.info
    raise_error = False
```

Both helpers go on to emit actual failure traces via `log_error`, e.g.:

```python
log_error(f"Failed to remove image {image_id}: {e}\n{traceback.format_exc()}")
log_error(f"Failed to stop container {container.name}: {e}. Trying to forcefully kill...")
```

Because the real-logger branch binds `log_error` to `logger.info`, any caller running the harness with an `ERROR`/`WARNING` log level silently drops these tracebacks. The print branch (`log_error = print`) and the quiet branch (`log_error = lambda x: None`) both behave as intended; only the `logger`-object branch mis-levels errors.

## Root cause

Copy-paste: `log_info = logger.info` was duplicated into the `log_error` slot when this branch was written, so both callbacks end up on the same severity channel.

## Why the fix is correct

Routing `log_error` through `logger.error` restores the severity distinction the docstring and the other two branches already assume. `log_info` stays on `logger.info`. The `raise_error = False` flow is unchanged — callers that want exceptions still set the flag themselves.

## Change

Two identical one-word edits (`logger.info` → `logger.error`) on `log_error = ...` in the `else` branches of `remove_image` and `cleanup_container`. No signature, import, or behaviour change beyond the log level.