### PR TITLE
Fix call_chat returning bare None on context_length_exceeded breaking tuple unpack

### DIFF
--- a/swebench/inference/run_api.py
+++ b/swebench/inference/run_api.py
@@ -155,7 +155,7 @@ def call_chat(model_name_or_path, inputs, use_azure, temperature, top_p, **model
     except openai.BadRequestError as e:
         if e.code == "context_length_exceeded":
             print("Context length exceeded")
-            return None
+            return None, 0
         raise e
 
 
@@ -231,6 +231,8 @@ def openai_inference(
                 temperature,
                 top_p,
             )
+            if response is None:
+                continue
             completion = response.choices[0].message.content
             total_cost += cost
             print(f"Total Cost: {total_cost:.2f}")


### PR DESCRIPTION
## Bug

`swebench/inference/run_api.py::call_chat` returns `(response, cost)` on the success path:

```python
input_tokens = response.usage.prompt_tokens
output_tokens = response.usage.completion_tokens
cost = calc_cost(response.model, input_tokens, output_tokens)
return response, cost
```

Its context-overflow handler, however, bails out with a bare `None`:

```python
except openai.BadRequestError as e:
    if e.code == "context_length_exceeded":
        print("Context length exceeded")
        return None
    raise e
```

`openai_inference` unpacks the call unconditionally:

```python
response, cost = call_chat(
    output_dict["model_name_or_path"],
    output_dict["text"],
    use_azure,
    temperature,
    top_p,
)
completion = response.choices[0].message.content
```

Any instance that trips the context-length guard aborts the whole inference loop with

```
TypeError: cannot unpack non-iterable NoneType object
```

instead of the intended "print a warning and skip this instance" — the `print("Context length exceeded")` two lines above makes it clear the author wanted to continue to the next instance, not crash the run.

## Root cause

Return-shape drift: the success path evolved into a 2-tuple (response, cost) but the `context_length_exceeded` handler never got updated.

## Fix

Two-part minimal fix in the same file:

1. Return the documented 2-tuple shape with a zero cost on the context-overflow path so unpacking still works:
   ```diff
    except openai.BadRequestError as e:
        if e.code == "context_length_exceeded":
            print("Context length exceeded")
   -        return None
   +        return None, 0
            raise e
   ```
2. Guard the caller so the writer doesn't try `response.choices` on a `None` value:
   ```diff
                temperature,
                top_p,
            )
   +        if response is None:
   +            continue
            completion = response.choices[0].message.content
   ```

Three added lines, one removed. No behaviour change for instances that fit; over-length instances now print the existing warning and continue, which matches the author's intent and the retry decorator's "skip transient failures elsewhere" pattern.