### PR TITLE
fix(harness): guard resource import for Windows compatibility

### DIFF
--- a/swebench/harness/prepare_images.py
+++ b/swebench/harness/prepare_images.py
@@ -1,5 +1,8 @@
 import docker
-import resource
+try:
+    import resource
+except ImportError:
+    resource = None  # type: ignore[assignment]
 
 from argparse import ArgumentParser
 
@@ -82,8 +85,9 @@ def main(
         force_rebuild (bool): Whether to force rebuild all images.
         open_file_limit (int): Open file limit.
     """
-    # Set open file limit
-    resource.setrlimit(resource.RLIMIT_NOFILE, (open_file_limit, open_file_limit))
+    # Set open file limit (resource module is Unix-only)
+    if resource is not None:
+        resource.setrlimit(resource.RLIMIT_NOFILE, (open_file_limit, open_file_limit))
     client = docker.from_env()
 
     # Filter out instances that were not specified
@@ -148,3 +152,4 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
     main(**vars(args))
+


### PR DESCRIPTION
**Bug:** `swebench/harness/prepare_images.py` does an unconditional `import resource` at module level and then unconditionally calls `resource.setrlimit(...)`. The `resource` module is Unix-only and does not exist on Windows, causing an `ImportError` at import time and making the entire `prepare_images` module unusable on Windows.

**Root cause:** `resource` is a POSIX stdlib module. Importing it at the top level without a guard crashes on any non-Unix platform before `main()` is even called.

**Fix:** Wrap the import in a `try/except ImportError` with a `None` fallback (matching the pattern already used in the repo for other platform-specific modules), then guard the `setrlimit` call with `if resource is not None:`. No behavior change on Unix; Windows can now import and run the module for the code paths that don't rely on file-descriptor limits.