### PR TITLE
fix(harness reporting): include docker leftovers in report under 'if client', not 'if not client'

### DIFF
--- a/swebench/harness/reporting.py
+++ b/swebench/harness/reporting.py
@@ -141,7 +141,7 @@ def make_run_report(
         "error_ids": list(sorted(error_ids)),
         "schema_version": 2,
     }
-    if not client:
+    if client:
         report.update(
             {
                 "unstopped_instances": len(unstopped_containers),


### PR DESCRIPTION
## Bug

In \`make_run_report\` (\`swebench/harness/reporting.py\`), the JSON report includes \`unstopped_instances\` / \`unstopped_containers\` / \`unremoved_images\` exactly when a docker \`client\` is **not** supplied. So when a client is passed in, the report omits the leftover-resource fields that were just collected; when no client is passed in, the report gains three always-empty fields whose source sets were never populated.

## Root cause

The collection and console-print of those fields are both gated on \`if client:\`:

\`\`\`python
if client:
    # populate unstopped_containers / unremoved_images
    ...

if client:
    print(f\"Unstopped containers: {len(unstopped_containers)}\")
    print(f\"Unremoved images: {len(unremoved_images)}\")
\`\`\`

But the matching \`report.update(...)\` was guarded the other way around:

\`\`\`python
if not client:
    report.update({
        \"unstopped_instances\": ...,
        \"unstopped_containers\": ...,
        \"unremoved_images\": ...,
    })
\`\`\`

The docstring also states the function \"Also reports on images and containers that may still running if client is provided\" — confirming the intent is \`if client\`.

## Fix

Drop the \`not\` so the report update lives in the same branch as the population and printing. One-character change; no other behavior is affected.