### PR TITLE
Disable nose plugin for Astropy pytest execution to avoid collection crash

### DIFF
--- a/swebench/harness/constants/python.py
+++ b/swebench/harness/constants/python.py
@@ -1,7 +1,7 @@
 # Constants - Testing Commands
 TEST_PYTEST = "pytest --no-header -rA --tb=no -p no:cacheprovider"
 TEST_PYTEST_VERBOSE = "pytest -rA --tb=long -p no:cacheprovider"
-TEST_ASTROPY_PYTEST = "pytest -rA -vv -o console_output_style=classic --tb=no"
+TEST_ASTROPY_PYTEST = "pytest -rA -vv -o console_output_style=classic --tb=no -p no:nose"
 TEST_DJANGO = "./tests/runtests.py --verbosity 2 --settings=test_sqlite --parallel 1"
 TEST_DJANGO_NO_PARALLEL = "./tests/runtests.py --verbosity 2"
 TEST_SEABORN = "pytest --no-header -rA"


### PR DESCRIPTION
Bug:
When running legacy Astropy evaluation tasks (such as `astropy__astropy-8707`), the evaluation harness crashes during the pytest test collection stage.

Root Cause:
Legacy Astropy versions depend on `nose` which is deprecated. In modern test runners (like the `pytest` version used in the SWE-bench evaluation harness), trying to load/parse the `nose` plugin leads to a severe compatibility and collection crash, preventing the tests from executing.

Why Fix is Correct:
Appending `-p no:nose` to `TEST_ASTROPY_PYTEST` disables the deprecated `nose` plugin under pytest. This prevents the collection conflict and allows pytest to successfully load and execute Astropy tests.