### PR TITLE
Fix: Downgrade setuptools for astropy 3.1 to resolve pytest collection error

### DIFF
--- a/swebench/harness/constants/python.py
+++ b/swebench/harness/constants/python.py
@@ -565,6 +565,13 @@ SPECS_ASTROPY = {
     }
     for k in ["3.0", "3.1", "3.2", "4.1", "4.2", "4.3", "5.0", "5.1", "5.2", "v5.3"]
 }
+
+# Override setuptools version for astropy 3.1 to fix pytest collection error
+# due to distutils DeprecationWarning when using setuptools >= 60.
+SPECS_ASTROPY["3.1"]["pip_packages"] = [
+    pkg if pkg != "setuptools==68.0.0" else "setuptools==59.8.0"
+    for pkg in SPECS_ASTROPY["3.1"]["pip_packages"]
+]
 SPECS_ASTROPY.update(
     {
         k: {


### PR DESCRIPTION
Bug: The evaluation of `astropy__astropy-8872` fails during test collection because `setuptools==68.0.0` (vendoring its own `distutils`) raises a `DeprecationWarning` when `LooseVersion` is instantiated. In astropy 3.1, pytest is configured to treat warnings as errors, causing collection to crash immediately. Root cause: `setuptools >= 60` emits a deprecation warning for `distutils.version.LooseVersion`. Why fix is correct: Pinning `setuptools==59.8.0` specifically for astropy 3.1 prevents the warning and allows the tests to run normally without collection failures.