### PR TITLE
fix: treat missing eval tests as failures in check_fail_only

### DIFF
--- a/swebench/harness/grading.py
+++ b/swebench/harness/grading.py
@@ -128,10 +128,7 @@ def get_eval_tests_report(
             failed.append(test_case)
 
     def check_fail_only(test_case, eval_status_map, success, failed):
-        if (
-            test_case in eval_status_map
-            and eval_status_map[test_case] == TestStatus.FAILED.value
-        ):
+        if test_failed(test_case, eval_status_map):
             failed.append(test_case)
         else:
             success.append(test_case)


### PR DESCRIPTION
## Summary

Fixes incorrect `resolved: true` results for fail-only repos when evaluation crashes before tests run (#474).

## Root cause

`check_fail_only` only marked a test as failed when it appeared in `eval_status_map` with status `FAILED`. Tests missing from the map (e.g. fatal `SyntaxError` before pytest collects anything) were counted as successes.

## Why this fix is correct

Reuse `test_failed`, which already treats absent or errored tests as failures—the same rule `check_pass_and_fail` relies on. Fail-only repos should not report resolution when the harness never produced a passing status for a gold test.

Fixes #474

## Test plan
- [ ] Re-run grading on a fail-only instance with a pre-test fatal error and confirm `resolved` is false


Made with [Cursor](https://cursor.com)