### PR TITLE
fix: disable nose pytest plugin for Astropy eval harness

### DIFF
--- a/swebench/harness/constants/python.py
+++ b/swebench/harness/constants/python.py
@@ -1,7 +1,7 @@
 # Constants - Testing Commands
 TEST_PYTEST = "pytest --no-header -rA --tb=no -p no:cacheprovider"
 TEST_PYTEST_VERBOSE = "pytest -rA --tb=long -p no:cacheprovider"
-TEST_ASTROPY_PYTEST = "pytest -rA -vv -o console_output_style=classic --tb=no"
+TEST_ASTROPY_PYTEST = "pytest -rA -vv -o console_output_style=classic --tb=no -p no:nose"
 TEST_DJANGO = "./tests/runtests.py --verbosity 2 --settings=test_sqlite --parallel 1"
 TEST_DJANGO_NO_PARALLEL = "./tests/runtests.py --verbosity 2"
 TEST_SEABORN = "pytest --no-header -rA"


### PR DESCRIPTION
## Summary
Fixes #530.

Astropy 3.1 instances like `astropy__astropy-8707` were graded as unresolved even when the gold patch passed locally, because pytest 7 auto-loads the deprecated `nose` plugin and aborts during collection.

## Root cause
`TEST_ASTROPY_PYTEST` did not disable the nose plugin. Other harness test commands already pass `-p no:...` flags (e.g. `TEST_PYTEST` uses `-p no:cacheprovider`).

## Fix
Append `-p no:nose` to `TEST_ASTROPY_PYTEST` so pytest skips the nose plugin and Astropy tests can run under the harness pytest version.

## Test plan
- [ ] Re-run gold evaluation for `astropy__astropy-8707` and confirm tests collect and resolve correctly

Made with [Cursor](https://cursor.com)