### PR TITLE
Add local benchmark stabilization hooks

### DIFF
--- a/swebench/harness/docker_build.py
+++ b/swebench/harness/docker_build.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import docker
 import docker.errors
 import logging
+import os
 import sys
 import traceback
 
@@ -513,7 +514,7 @@ def build_container(
         run_args = test_spec.docker_specs.get("run_args", {})
         cap_add = run_args.get("cap_add", [])
 
-        container = client.containers.create(
+        create_kwargs = dict(
             image=test_spec.instance_image_key,
             name=test_spec.get_instance_container_name(run_id),
             user=DOCKER_USER,
@@ -522,6 +523,30 @@ def build_container(
             platform=test_spec.platform,
             cap_add=cap_add,
         )
+
+        # Local benchmark stabilization hooks. If set by the caller, join the
+        # evaluation container to a user-defined Docker network and inject an
+        # HTTPBIN_URL so old Requests tests do not depend on live httpbin.org.
+        docker_network = os.environ.get("SWEBENCH_DOCKER_NETWORK")
+        if docker_network:
+            create_kwargs["network"] = docker_network
+            logger.info(f"Using Docker network from SWEBENCH_DOCKER_NETWORK={docker_network}")
+
+        container_env = {}
+        httpbin_url = os.environ.get("SWEBENCH_HTTPBIN_URL")
+        if httpbin_url:
+            container_env["HTTPBIN_URL"] = httpbin_url
+            logger.info(f"Injecting HTTPBIN_URL={httpbin_url}")
+
+        if os.environ.get("SWEBENCH_HTTPBIN_CA_CERT"):
+            container_env["REQUESTS_CA_BUNDLE"] = "/tmp/swebench-httpbin-ca.pem"
+            container_env["CURL_CA_BUNDLE"] = "/tmp/swebench-httpbin-ca.pem"
+            logger.info("Injecting REQUESTS_CA_BUNDLE/CURL_CA_BUNDLE for local HTTPBIN CA")
+
+        if container_env:
+            create_kwargs["environment"] = container_env
+
+        container = client.containers.create(**create_kwargs)
         logger.info(f"Container for {test_spec.instance_id} created: {container.id}")
         return container
     except Exception as e:

--- a/swebench/harness/run_evaluation.py
+++ b/swebench/harness/run_evaluation.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import docker
 import json
+import os
 import platform
 import threading
 import traceback
@@ -154,6 +155,28 @@ def run_instance(
         )
         container.start()
         logger.info(f"Container for {instance_id} started: {container.id}")
+
+        httpbin_ca = os.environ.get("SWEBENCH_HTTPBIN_CA_CERT")
+        if httpbin_ca:
+            ca_src = Path(httpbin_ca)
+            ca_dst = PurePosixPath("/tmp/swebench-httpbin-ca.pem")
+            ca_local_copy = Path(log_dir / "httpbin-ca.pem")
+            ca_local_copy.write_bytes(ca_src.read_bytes())
+            copy_to_container(container, ca_local_copy, ca_dst)
+            logger.info(f"Copied local HTTPBIN CA certificate to {ca_dst}")
+            append_cmd = (
+                "if [ -f /testbed/requests/cacert.pem ]; then "
+                "cat /tmp/swebench-httpbin-ca.pem >> /testbed/requests/cacert.pem; "
+                "echo appended_local_httpbin_ca_to_requests_bundle; "
+                "fi"
+            )
+            ca_append_result = container.exec_run(
+                ["/bin/bash", "-lc", append_cmd], workdir=DOCKER_WORKDIR, user=DOCKER_USER
+            )
+            logger.info(
+                "Local HTTPBIN CA install result "
+                f"exit={ca_append_result.exit_code}: {ca_append_result.output.decode(UTF8)}"
+            )
 
         # Copy model prediction as patch file to container
         patch_file = Path(log_dir / "patch.diff")

--- a/swebench/harness/test_spec/python.py
+++ b/swebench/harness/test_spec/python.py
@@ -271,7 +271,12 @@ def make_repo_script_list_py(
     branch = REPO_BASE_COMMIT_BRANCH.get(repo, {}).get(base_commit, "")
     branch = f"--branch {branch}" if branch else ""
     setup_commands = [
-        f"git clone -o origin {branch} --single-branch https://github.com/{repo} {repo_directory}",
+        # Local benchmark stabilization: GitHub clones inside linux/amd64 Docker
+        # builds can intermittently fail with RPC/GnuTLS early EOF. Retry only the
+        # repository fetch step; this does not change the checked-out commit,
+        # tests, or model patch semantics.
+        "git config --global http.version HTTP/1.1 || true",
+        f"cd / && for attempt in 1 2 3 4 5; do rm -rf {repo_directory}; git clone -o origin {branch} --single-branch https://github.com/{repo} {repo_directory} && break; status=$?; echo \"git clone failed with status $status on attempt $attempt/5\"; if [ \"$attempt\" -eq 5 ]; then exit \"$status\"; fi; sleep $((attempt * 5)); done",
         f"chmod -R 777 {repo_directory}",  # So nonroot user can run tests
         f"cd {repo_directory}",
         f"git reset --hard {base_commit}",

--- a/swebench/harness/test_spec/utils.py
+++ b/swebench/harness/test_spec/utils.py
@@ -27,7 +27,10 @@ def make_repo_script_list_common(
     This is the setup script for the instance image.
     """
     setup_commands = [
-        f"git clone -o origin https://github.com/{repo} {repo_directory}",
+        # Local benchmark stabilization: retry GitHub clones that fail before
+        # any tests or model patches are applied.
+        "git config --global http.version HTTP/1.1 || true",
+        f"cd / && for attempt in 1 2 3 4 5; do rm -rf {repo_directory}; git clone -o origin https://github.com/{repo} {repo_directory} && break; status=$?; echo \"git clone failed with status $status on attempt $attempt/5\"; if [ \"$attempt\" -eq 5 ]; then exit \"$status\"; fi; sleep $((attempt * 5)); done",
         f"chmod -R 777 {repo_directory}",  # So nonroot user can run tests
         f"cd {repo_directory}",
         f"git reset --hard {base_commit}",


### PR DESCRIPTION
Adds opt-in local benchmark stabilization hooks used for SWE-bench evaluation experiments.\n\nChanges:\n- Inject optional local HTTPBIN_URL and Docker network into eval containers.\n- Copy optional local httpbin CA into containers and Requests' bundled cacert.pem when present.\n- Retry repository clones inside instance image setup scripts to reduce transient RPC/GnuTLS early EOF failures.\n\nVerification:\n- python -m py_compile swebench/harness/docker_build.py swebench/harness/run_evaluation.py swebench/harness/test_spec/python.py swebench/harness/test_spec/utils.py\n\nNote: all hooks are opt-in via environment variables except the clone retry wrapper, which preserves the same repo URL/base commit and only retries pre-test setup fetches.