### PR TITLE
fix(harness): pin setuptools 59.8.0 for astropy 3.1

### DIFF
--- a/swebench/harness/constants/python.py
+++ b/swebench/harness/constants/python.py
@@ -565,6 +565,9 @@ SPECS_ASTROPY = {
     }
     for k in ["3.0", "3.1", "3.2", "4.1", "4.2", "4.3", "5.0", "5.1", "5.2", "v5.3"]
 }
+SPECS_ASTROPY["3.1"]["pip_packages"] = [
+    p.replace("setuptools==68.0.0", "setuptools==59.8.0") for p in SPECS_ASTROPY["3.1"]["pip_packages"]
+]
 SPECS_ASTROPY.update(
     {
         k: {


### PR DESCRIPTION
Fixes #584

The astropy 3.1 spec pins `setuptools==68.0.0`. Setuptools ≥60 ships a vendored `distutils` whose `LooseVersion` emits a `DeprecationWarning` at import time. Astropy 3.1 pytest config treats warnings as errors, so collection aborts before any test runs — gold patches for instances like `astropy__astropy-8872` always score `resolved: false`.

Pin `setuptools==59.8.0` for the 3.1 spec only so collection uses stdlib distutils without the warning.

Made with [Cursor](https://cursor.com)