### PR TITLE
fix(harness): reject model patches that modify test or CI files

### DIFF
--- a/swebench/harness/modal_eval/run_evaluation_modal.py
+++ b/swebench/harness/modal_eval/run_evaluation_modal.py
@@ -15,7 +15,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from swebench.harness.docker_build import setup_logger
 from swebench.harness.reporting import make_run_report
-from swebench.harness.utils import EvaluationError
+from swebench.harness.utils import EvaluationError, validate_model_patch_paths
 from typing import cast
 
 SANDBOX_ENTRYPOINT = "run_evaluation_modal_entrypoint"
@@ -264,6 +264,9 @@ def run_instance_modal(
         ) from e
 
     patch_diff = pred.get("model_patch", "")
+    patch_error = validate_model_patch_paths(patch_diff)
+    if patch_error:
+        raise EvaluationError(instance_id, patch_error, logger)
 
     try:
         patch_file = "/tmp/patch.diff"

--- a/swebench/harness/run_evaluation.py
+++ b/swebench/harness/run_evaluation.py
@@ -59,6 +59,7 @@ from swebench.harness.utils import (
     run_threadpool,
     str2bool,
     optional_str,
+    validate_model_patch_paths,
 )
 
 GIT_APPLY_CMDS = [
@@ -157,7 +158,11 @@ def run_instance(
 
         # Copy model prediction as patch file to container
         patch_file = Path(log_dir / "patch.diff")
-        patch_file.write_text(pred[KEY_PREDICTION] or "")
+        patch_text = pred[KEY_PREDICTION] or ""
+        patch_error = validate_model_patch_paths(patch_text)
+        if patch_error:
+            raise EvaluationError(instance_id, patch_error, logger)
+        patch_file.write_text(patch_text)
         logger.info(
             f"Intermediate patch for {instance_id} written to {patch_file}, now applying to container..."
         )

--- a/swebench/harness/utils.py
+++ b/swebench/harness/utils.py
@@ -348,6 +348,60 @@ def get_modified_files(patch: str) -> list[str]:
     return source_files
 
 
+def get_all_patch_paths(patch: str) -> list[str]:
+    """
+    Get all file paths touched by a patch (modified and newly added files).
+    """
+    return get_modified_files(patch) + get_new_files(patch)
+
+
+def _is_forbidden_model_patch_path(path: str) -> bool:
+    """
+    Return True if a model-generated patch must not modify the given path.
+    """
+    norm = path.lstrip("./")
+    parts = norm.split("/")
+    basename = parts[-1]
+
+    if any(part in {"tests", "test", "testing"} for part in parts):
+        return True
+    if parts and parts[0] in {".github", ".circleci", ".travis", ".gitlab-ci"}:
+        return True
+    if basename == "conftest.py":
+        return True
+    if basename.startswith("test_") and "." in basename:
+        return True
+    if basename.endswith("_test.py"):
+        return True
+    if basename in {"pytest.ini", "tox.ini", "setup.cfg"}:
+        return True
+    return False
+
+
+def validate_model_patch_paths(patch: str) -> str | None:
+    """
+    Reject model patches that modify test or CI configuration files.
+
+    Returns an error message if the patch is invalid, otherwise None.
+    """
+    if not patch.strip():
+        return None
+
+    try:
+        forbidden_paths = [
+            path
+            for path in get_all_patch_paths(patch)
+            if _is_forbidden_model_patch_path(path)
+        ]
+    except Exception:
+        return "Unable to parse model patch"
+
+    if forbidden_paths:
+        joined = ", ".join(sorted(set(forbidden_paths)))
+        return f"Model patch modifies forbidden paths: {joined}"
+    return None
+
+
 def get_new_files(patch: str) -> list[str]:
     """
     Get the list of new files in a patch (source is /dev/null).

--- a/tests/test_harness_utils.py
+++ b/tests/test_harness_utils.py
@@ -1,5 +1,8 @@
 import unittest
-from swebench.harness.utils import run_threadpool
+from swebench.harness.utils import (
+    run_threadpool,
+    validate_model_patch_paths,
+)
 from swebench.harness.test_spec.python import clean_environment_yml, clean_requirements
 
 
@@ -195,3 +198,25 @@ class UtilTests(unittest.TestCase):
         )
         cleaned = clean_requirements(requirements)
         self.assertEqual(cleaned, expected_requirements)
+
+    def test_validate_model_patch_paths_rejects_test_files(self):
+        patch = (
+            "--- a/tests/test_core.py\n"
+            "+++ b/tests/test_core.py\n"
+            "@@ -1,2 +1,2 @@\n"
+            "-assert process_data() == expected\n"
+            "+assert True\n"
+        )
+        error = validate_model_patch_paths(patch)
+        self.assertIsNotNone(error)
+        self.assertIn("tests/test_core.py", error)
+
+    def test_validate_model_patch_paths_allows_source_files(self):
+        patch = (
+            "--- a/src/core.py\n"
+            "+++ b/src/core.py\n"
+            "@@ -1,2 +1,2 @@\n"
+            "-return 0\n"
+            "+return 1\n"
+        )
+        self.assertIsNone(validate_model_patch_paths(patch))


### PR DESCRIPTION
## Summary
- Add `validate_model_patch_paths()` to reject model patches targeting test suites or CI config before `git apply` (Fixes #600)
- Apply validation in both Docker and Modal evaluation paths
- Add unit tests for allowed source patches vs. forbidden test-file patches

## Test plan
- [ ] `python -m pytest tests/test_harness_utils.py::UtilTests::test_validate_model_patch_paths_rejects_test_files`
- [ ] Evaluation run with a malicious test-file patch fails early with a clear error instead of recording a false positive

Made with [Cursor](https://cursor.com)