### PR TITLE
fix(harness): set deterministic env vars on eval containers

### DIFF
--- a/swebench/harness/constants/__init__.py
+++ b/swebench/harness/constants/__init__.py
@@ -71,6 +71,12 @@ KEY_PREDICTION = "model_patch"
 DOCKER_PATCH = "/tmp/patch.diff"
 DOCKER_USER = "root"
 DOCKER_WORKDIR = "/testbed"
+# Normalize runtime environment for evaluation containers to improve determinism.
+DOCKER_CONTAINER_ENV = {
+    "TZ": "UTC",
+    "PYTHONHASHSEED": "0",
+    "LANG": "C.UTF-8",
+}
 LOG_REPORT = "report.json"
 LOG_INSTANCE = "run_instance.log"
 LOG_TEST_OUTPUT = "test_output.txt"

--- a/swebench/harness/docker_build.py
+++ b/swebench/harness/docker_build.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 from swebench.harness.constants import (
     BASE_IMAGE_BUILD_DIR,
+    DOCKER_CONTAINER_ENV,
     DOCKER_USER,
     ENV_IMAGE_BUILD_DIR,
     INSTANCE_IMAGE_BUILD_DIR,
@@ -521,6 +522,7 @@ def build_container(
             command="tail -f /dev/null",
             platform=test_spec.platform,
             cap_add=cap_add,
+            environment=DOCKER_CONTAINER_ENV,
         )
         logger.info(f"Container for {test_spec.instance_id} created: {container.id}")
         return container


### PR DESCRIPTION
## Summary

Sets normalized environment variables (`TZ=UTC`, `PYTHONHASHSEED=0`, `LANG=C.UTF-8`) when creating evaluation instance containers. This reduces timezone and hash-randomization drift during parallel harness runs.

Fixes #602

## Test plan

- [ ] Run a small SWE-bench Verified evaluation with `max_workers > 1` and confirm identical patches produce stable results across repeated runs
- [ ] Verify containers start successfully with the new `environment` argument

Made with [Cursor](https://cursor.com)