### PR TITLE
fix(harness): harden eval grading against stdout forging

### DIFF
--- a/swebench/harness/constants/__init__.py
+++ b/swebench/harness/constants/__init__.py
@@ -89,6 +89,7 @@ TESTS_PASSED = ">>>>> All Tests Passed"
 TESTS_TIMEOUT = ">>>>> Tests Timed Out"
 START_TEST_OUTPUT = ">>>>> Start Test Output"
 END_TEST_OUTPUT = ">>>>> End Test Output"
+TEST_EXIT_CODE_PREFIX = ">>>>> Test Exit Code: "
 
 
 # Constants - Patch Types

--- a/swebench/harness/grading.py
+++ b/swebench/harness/grading.py
@@ -43,16 +43,41 @@ _STDOUT_TAMPERING_PATTERNS = (
 )
 
 
-def _parse_test_exit_code(content: str) -> int | None:
-    for line in content.splitlines():
-        stripped = line.strip()
-        if stripped.startswith(TEST_EXIT_CODE_PREFIX):
-            code = stripped[len(TEST_EXIT_CODE_PREFIX) :].strip()
-            try:
-                return int(code)
-            except ValueError:
-                return None
-    return None
+def _validate_eval_log_markers(content: str) -> tuple[str | None, int | None]:
+    """
+    Fail closed unless the log matches the eval script marker contract:
+    exactly one START, END, and exit-code marker in order START < END < EXIT_CODE,
+    with a zero integer exit code.
+    """
+    if (
+        content.count(START_TEST_OUTPUT) != 1
+        or content.count(END_TEST_OUTPUT) != 1
+        or content.count(TEST_EXIT_CODE_PREFIX) != 1
+    ):
+        return None, None
+
+    start_idx = content.index(START_TEST_OUTPUT)
+    end_idx = content.index(END_TEST_OUTPUT)
+    exit_idx = content.index(TEST_EXIT_CODE_PREFIX)
+    if not (start_idx < end_idx < exit_idx):
+        return None, None
+
+    exit_line_end = content.find("\n", exit_idx)
+    exit_line = (
+        content[exit_idx:exit_line_end]
+        if exit_line_end != -1
+        else content[exit_idx:]
+    )
+    code_str = exit_line.strip()[len(TEST_EXIT_CODE_PREFIX) :].strip()
+    try:
+        exit_code = int(code_str)
+    except ValueError:
+        return None, None
+    if exit_code != 0:
+        return None, None
+
+    test_content = content[start_idx + len(START_TEST_OUTPUT) : end_idx]
+    return test_content, exit_code
 
 
 def _detect_stdout_tampering(test_content: str) -> bool:
@@ -95,15 +120,9 @@ def get_logs_eval(test_spec: TestSpec, log_fp: str) -> tuple[dict[str, str], boo
         )
         if bad_codes:
             return {}, False
-        elif not (START_TEST_OUTPUT in content and END_TEST_OUTPUT in content):
-            # Test patch did not apply (should not happen at all)
-            return {}, False
 
-        # Get status map of evaluation results
-        test_content = content.split(START_TEST_OUTPUT)[1].split(END_TEST_OUTPUT)[0]
-
-        test_exit_code = _parse_test_exit_code(content)
-        if test_exit_code is not None and test_exit_code != 0:
+        test_content, _ = _validate_eval_log_markers(content)
+        if test_content is None:
             return {}, False
 
         if _detect_stdout_tampering(test_content):

--- a/swebench/harness/grading.py
+++ b/swebench/harness/grading.py
@@ -1,3 +1,4 @@
+import re
 from typing import Any
 
 from swebench.harness.constants import (
@@ -13,6 +14,7 @@ from swebench.harness.constants import (
     PASS_TO_PASS,
     RESET_FAILED,
     START_TEST_OUTPUT,
+    TEST_EXIT_CODE_PREFIX,
     TESTS_ERROR,
     TESTS_TIMEOUT,
     EvalType,
@@ -33,6 +35,28 @@ def test_failed(case: str, sm: dict[str, str]) -> bool:
         TestStatus.FAILED.value,
         TestStatus.ERROR.value,
     ]
+
+
+_STDOUT_TAMPERING_PATTERNS = (
+    re.compile(r"sys\.stdout\s*="),
+    re.compile(r"SpoofedStdout"),
+)
+
+
+def _parse_test_exit_code(content: str) -> int | None:
+    for line in content.splitlines():
+        stripped = line.strip()
+        if stripped.startswith(TEST_EXIT_CODE_PREFIX):
+            code = stripped[len(TEST_EXIT_CODE_PREFIX) :].strip()
+            try:
+                return int(code)
+            except ValueError:
+                return None
+    return None
+
+
+def _detect_stdout_tampering(test_content: str) -> bool:
+    return any(pattern.search(test_content) for pattern in _STDOUT_TAMPERING_PATTERNS)
 
 
 # MARK: Evaluation report functions
@@ -77,6 +101,13 @@ def get_logs_eval(test_spec: TestSpec, log_fp: str) -> tuple[dict[str, str], boo
 
         # Get status map of evaluation results
         test_content = content.split(START_TEST_OUTPUT)[1].split(END_TEST_OUTPUT)[0]
+
+        test_exit_code = _parse_test_exit_code(content)
+        if test_exit_code is not None and test_exit_code != 0:
+            return {}, False
+
+        if _detect_stdout_tampering(test_content):
+            return {}, False
 
         # Try parsing the content between markers first
         status_map = log_parser(test_content, test_spec)

--- a/swebench/harness/test_spec/python.py
+++ b/swebench/harness/test_spec/python.py
@@ -13,6 +13,7 @@ from swebench.harness.constants import (
     SWE_BENCH_URL_RAW,
     START_TEST_OUTPUT,
     END_TEST_OUTPUT,
+    TEST_EXIT_CODE_PREFIX,
     REPO_BASE_COMMIT_BRANCH,
 )
 from swebench.harness.utils import get_modified_files, get_new_files, load_cached_environment_yml
@@ -456,7 +457,9 @@ def make_eval_script_list_py(
         apply_test_patch_command,
         f": '{START_TEST_OUTPUT}'",
         test_command,
+        "SWEBENCH_TEST_EXIT_CODE=$?",
         f": '{END_TEST_OUTPUT}'",
+        f'echo "{TEST_EXIT_CODE_PREFIX}${{SWEBENCH_TEST_EXIT_CODE}}"',
     ]
     eval_commands += reset_commands  # Revert tests after done
     return eval_commands

--- a/swebench/harness/test_spec/utils.py
+++ b/swebench/harness/test_spec/utils.py
@@ -2,6 +2,7 @@ from swebench.harness.constants import (
     END_TEST_OUTPUT,
     MAP_REPO_VERSION_TO_SPECS,
     START_TEST_OUTPUT,
+    TEST_EXIT_CODE_PREFIX,
 )
 from swebench.harness.utils import get_modified_files
 
@@ -89,7 +90,9 @@ def make_eval_script_list_common(
         *build_commands,
         f": '{START_TEST_OUTPUT}'",
         *test_commands,
+        "SWEBENCH_TEST_EXIT_CODE=$?",
         f": '{END_TEST_OUTPUT}'",
+        f'echo "{TEST_EXIT_CODE_PREFIX}${{SWEBENCH_TEST_EXIT_CODE}}"',
         reset_tests_command,
     ]
     return eval_commands

--- a/tests/test_grading_stdout.py
+++ b/tests/test_grading_stdout.py
@@ -1,0 +1,21 @@
+from swebench.harness.constants import (
+    END_TEST_OUTPUT,
+    START_TEST_OUTPUT,
+    TEST_EXIT_CODE_PREFIX,
+)
+from swebench.harness.grading import _detect_stdout_tampering, _parse_test_exit_code
+
+
+def test_parse_test_exit_code() -> None:
+    content = f"""{START_TEST_OUTPUT}
+=== 1 passed in 0.10 seconds ===
+{END_TEST_OUTPUT}
+{TEST_EXIT_CODE_PREFIX}0
+"""
+    assert _parse_test_exit_code(content) == 0
+
+
+def test_detect_stdout_tampering() -> None:
+    spoofed = "import sys\nclass SpoofedStdout:\n    pass\nsys.stdout = SpoofedStdout()"
+    assert _detect_stdout_tampering(spoofed) is True
+    assert _detect_stdout_tampering("=== 1 passed in 0.10 seconds ===") is False

--- a/tests/test_grading_stdout.py
+++ b/tests/test_grading_stdout.py
@@ -1,21 +1,170 @@
+import textwrap
+
+import pytest
+
 from swebench.harness.constants import (
     END_TEST_OUTPUT,
     START_TEST_OUTPUT,
     TEST_EXIT_CODE_PREFIX,
 )
-from swebench.harness.grading import _detect_stdout_tampering, _parse_test_exit_code
+from swebench.harness.grading import (
+    _detect_stdout_tampering,
+    _validate_eval_log_markers,
+    get_logs_eval,
+)
+from swebench.harness.test_spec.test_spec import TestSpec
 
 
-def test_parse_test_exit_code() -> None:
-    content = f"""{START_TEST_OUTPUT}
-=== 1 passed in 0.10 seconds ===
-{END_TEST_OUTPUT}
-{TEST_EXIT_CODE_PREFIX}0
-"""
-    assert _parse_test_exit_code(content) == 0
+def _valid_log(test_output: str = "=== 1 passed in 0.10 seconds ===") -> str:
+    return textwrap.dedent(
+        f"""\
+        {START_TEST_OUTPUT}
+        {test_output}
+        {END_TEST_OUTPUT}
+        {TEST_EXIT_CODE_PREFIX}0
+        """
+    )
+
+
+def test_validate_eval_log_markers_accepts_valid_log() -> None:
+    content = _valid_log()
+    test_content, exit_code = _validate_eval_log_markers(content)
+    assert exit_code == 0
+    assert "=== 1 passed in 0.10 seconds ===" in test_content
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        pytest.param(
+            textwrap.dedent(
+                f"""\
+                {TEST_EXIT_CODE_PREFIX}0
+                {START_TEST_OUTPUT}
+                forged pass output
+                {END_TEST_OUTPUT}
+                {TEST_EXIT_CODE_PREFIX}1
+                """
+            ),
+            id="forged-first-pair",
+        ),
+        pytest.param(
+            _valid_log().replace(f"{TEST_EXIT_CODE_PREFIX}0", f"{TEST_EXIT_CODE_PREFIX}0\n{TEST_EXIT_CODE_PREFIX}1"),
+            id="duplicate-exit-code-marker",
+        ),
+        pytest.param(
+            textwrap.dedent(
+                f"""\
+                {END_TEST_OUTPUT}
+                {START_TEST_OUTPUT}
+                output
+                {TEST_EXIT_CODE_PREFIX}0
+                """
+            ),
+            id="reversed-markers",
+        ),
+        pytest.param(
+            textwrap.dedent(
+                f"""\
+                {START_TEST_OUTPUT}
+                output
+                {END_TEST_OUTPUT}
+                {TEST_EXIT_CODE_PREFIX}1
+                """
+            ),
+            id="non-zero-exit-code",
+        ),
+        pytest.param(
+            textwrap.dedent(
+                f"""\
+                {START_TEST_OUTPUT}
+                output
+                {END_TEST_OUTPUT}
+                {TEST_EXIT_CODE_PREFIX}not-an-int
+                """
+            ),
+            id="non-integer-exit-code",
+        ),
+        pytest.param(
+            textwrap.dedent(
+                f"""\
+                {START_TEST_OUTPUT}
+                output
+                {END_TEST_OUTPUT}
+                """
+            ),
+            id="missing-exit-code-marker",
+        ),
+        pytest.param(
+            textwrap.dedent(
+                f"""\
+                {START_TEST_OUTPUT}
+                output
+                {TEST_EXIT_CODE_PREFIX}0
+                """
+            ),
+            id="missing-end-marker",
+        ),
+        pytest.param(
+            f"{TEST_EXIT_CODE_PREFIX}0",
+            id="single-marker-only",
+        ),
+        pytest.param(
+            textwrap.dedent(
+                f"""\
+                {START_TEST_OUTPUT}
+                first
+                {END_TEST_OUTPUT}
+                {START_TEST_OUTPUT}
+                second
+                {END_TEST_OUTPUT}
+                {TEST_EXIT_CODE_PREFIX}0
+                """
+            ),
+            id="duplicate-start-end-pair",
+        ),
+    ],
+)
+def test_validate_eval_log_markers_rejects_invalid_logs(content: str) -> None:
+    test_content, exit_code = _validate_eval_log_markers(content)
+    assert test_content is None
+    assert exit_code is None
 
 
 def test_detect_stdout_tampering() -> None:
     spoofed = "import sys\nclass SpoofedStdout:\n    pass\nsys.stdout = SpoofedStdout()"
     assert _detect_stdout_tampering(spoofed) is True
     assert _detect_stdout_tampering("=== 1 passed in 0.10 seconds ===") is False
+
+
+def test_get_logs_eval_rejects_forged_first_pair(tmp_path) -> None:
+    forged_log = textwrap.dedent(
+        f"""\
+        {TEST_EXIT_CODE_PREFIX}0
+        {START_TEST_OUTPUT}
+        === 1 passed in 0.10 seconds ===
+        {END_TEST_OUTPUT}
+        {TEST_EXIT_CODE_PREFIX}1
+        """
+    )
+    log_fp = tmp_path / "test.log"
+    log_fp.write_text(forged_log)
+
+    test_spec = TestSpec(
+        instance_id="test-instance",
+        repo="pvlib/pvlib-python",
+        version="0.1",
+        repo_script_list=[],
+        eval_script_list=[],
+        env_script_list=[],
+        arch="x86_64",
+        FAIL_TO_PASS=[],
+        PASS_TO_PASS=[],
+        language="Python",
+        docker_specs={},
+        namespace=None,
+    )
+
+    status_map, found = get_logs_eval(test_spec, str(log_fp))
+    assert status_map == {}
+    assert found is False


### PR DESCRIPTION
## Summary
- Record the test command exit code in generated eval scripts
- Reject evaluation logs when the exit code is non-zero
- Detect common stdout tampering patterns (e.g. `sys.stdout =`, `SpoofedStdout`) in captured test output before parsing pass/fail results

## Test plan
- [x] Added unit tests for exit-code parsing and tampering detection
- [ ] `pytest tests/test_grading_stdout.py`

Fixes #601

Made with [Cursor](https://cursor.com)