### PR TITLE
perf(harness): make list_images a single API call

### DIFF
--- a/swebench/harness/docker_utils.py
+++ b/swebench/harness/docker_utils.py
@@ -259,8 +259,20 @@ def list_images(client: docker.DockerClient):
     """
     List all images from the Docker client.
     """
-    # don't use this in multi-threaded context
-    return {tag for i in client.images.list(all=True) for tag in i.tags}
+    # Use the low-level API instead of client.images.list(all=True). The latter
+    # is implemented as [self.get(r["Id"]) for r in resp], i.e. it issues a
+    # separate GET /images/{id}/json for every image on the host. With many
+    # images that is one round-trip per image and floods the daemon when several
+    # evaluations run concurrently (hence the original "don't use in
+    # multi-threaded context" note). GET /images/json already returns RepoTags,
+    # so a single request yields the identical tag set. Image.tags drops the
+    # "<none>:<none>" placeholder, so match that here.
+    return {
+        tag
+        for img in client.api.images(all=True)
+        for tag in (img.get("RepoTags") or [])
+        if tag != "<none>:<none>"
+    }
 
 
 def clean_images(


### PR DESCRIPTION
## What

Make `swebench.harness.docker_utils.list_images` issue a single Docker API
call instead of one round-trip per image.

## Why

`list_images` is implemented on top of docker-py's
`client.images.list(all=True)`. That call is
`[self.get(r["Id"]) for r in resp]` under the hood, so it fires a **separate
`GET /images/{id}/json` for every image on the host**. On a machine with many
cached SWE-bench images this becomes one round-trip per image.

`list_images` is called by `clean_images` and by
`reporting.make_run_report` — and `run_evaluation` calls `make_run_report` at
the end of **every** run. When many `run_evaluation` processes run
concurrently (e.g. one per instance at high parallelism), they each enumerate
every image on the host, saturating the Docker daemon. This is precisely what
the existing comment warns about:

```python
# don't use this in multi-threaded context
return {tag for i in client.images.list(all=True) for tag in i.tags}
```

## How

`GET /images/json` already includes `RepoTags`, so the low-level
`client.api.images(all=True)` returns the same information in a single request.
Building the tag set from that response (filtering the `<none>:<none>`
placeholder, which `Image.tags` also drops) yields an **identical** result set
with no per-image inspects.

## Impact

Measured on a host with ~1450 images:

| | time | Docker round-trips |
|---|---|---|
| before | ~31 s | 1 list + ~1450 inspects |
| after | ~3 s | 1 |

Verified the returned tag set is identical before/after. No behavior change for
callers; removes the multi-threaded footgun.
